### PR TITLE
Remove envs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,18 +1,17 @@
 import * as constants from './lib/constants'
-import address from './lib/address'
+import { addressApiFactory, addressModuleFactory } from './lib/address'
 import * as crypto from './lib/crypto'
 import * as backendApiFactory from './lib/backend-api'
-import transaction from './lib/transaction'
-import wallet from './lib/wallet'
-import key from './lib/key'
+import { transactionApiFactory, transactionModuleFactory } from './lib/transaction'
+import { walletApiFactory } from './lib/wallet'
+import { keyApiFactory, keyModuleFactory } from './lib/key'
 import user from './lib/user'
 import * as transfers from './lib/transfers'
-import * as config from './lib/config'
 import { Currency } from "./types/domain";
 import bitcoinOps from './lib/bitcoin'
 import { BitcoinOperations } from './lib/bitcoin-operations';
 
-export default async (backendApiUrl: string) => {
+export const sakiewkaApi = async (backendApiUrl: string) => {
   const backendApi = backendApiFactory.create(backendApiUrl)
   const chainInfo = await backendApi.chainInfo()
 
@@ -22,27 +21,40 @@ export default async (backendApiUrl: string) => {
   const btgBackendApi = backendApiFactory.withCurrency(backendApiUrl, Currency.BTG)
   const btgOps = bitcoinOps(Currency.BTG, chainInfo.chain)
 
+  function creatCurrencyApi(backendApi: backendApiFactory.CurrencyBackendApi, bitcoinOps: BitcoinOperations) {
+    const keyApi = keyApiFactory(backendApi)
+    const keyModule = keyModuleFactory(bitcoinOps)
+    const walletApi = walletApiFactory(backendApi, keyModule)
+    return {
+      address: addressApiFactory(backendApi),
+      transaction: transactionApiFactory(backendApi, keyModule, bitcoinOps, walletApi),
+      wallet: walletApi,
+      key: keyApi
+    };
+  }
+
   return {
     user: user(backendApi),
     transfers,
-    config,
-    crypto,
-    [Currency.BTC]: creatCurrencyModule(btcBackendApi, btcOps),
-    [Currency.BTG]: creatCurrencyModule(btgBackendApi, btgOps),
+    [Currency.BTC]: creatCurrencyApi(btcBackendApi, btcOps),
+    [Currency.BTG]: creatCurrencyApi(btgBackendApi, btgOps),
   }
 }
 
-function creatCurrencyModule(backendApi: backendApiFactory.CurrencyBackendApi, bitcoinOps: BitcoinOperations) {
-  const keyModule = key(backendApi, bitcoinOps)
+export const sakiewkaModule = (currency: Currency, btcNetwork: string) => {
+  const bitcoinOperations = bitcoinOps(currency, btcNetwork);
+  const keyModule = keyModuleFactory(bitcoinOperations)
+  const transactionModule = transactionModuleFactory(keyModule, bitcoinOperations)
+  const addressModule = addressModuleFactory(bitcoinOperations, keyModule)
   return {
-    address: address(backendApi, bitcoinOps, keyModule),
-    transaction: transaction(backendApi, keyModule, bitcoinOps),
-    wallet: wallet(backendApi, keyModule),
-    key: keyModule
-  };
+    transaction: transactionModule,
+    address: addressModule,
+    key: keyModule,
+    bitcoin: bitcoinOperations,
+  }
 }
 
 
 export { Currency } from './types/domain'
 export { constants }
-
+export { crypto }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import * as constants from './lib/constants'
 import address from './lib/address'
 import * as crypto from './lib/crypto'
+import * as backendApiFactory from './lib/backend-api'
 import transaction from './lib/transaction'
 import wallet from './lib/wallet'
 import key from './lib/key'
@@ -9,7 +10,8 @@ import * as transfers from './lib/transfers'
 import * as config from './lib/config'
 import { Currency } from "./types/domain";
 
-export default (backendApiUrl: string) => {
+export default async (backendApiUrl: string) => {
+  const chainInfo = await backendApiFactory.create(backendApiUrl)
   return {
     user: user(backendApiUrl),
     transfers,

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,28 +4,30 @@ import * as crypto from './lib/crypto'
 import transaction from './lib/transaction'
 import wallet from './lib/wallet'
 import key from './lib/key'
-import * as user from './lib/user'
+import user from './lib/user'
 import * as transfers from './lib/transfers'
 import * as config from './lib/config'
 import { Currency } from "./types/domain";
 
-export default {
-  user,
-  transfers,
-  config,
-  constants,
-  crypto,
-  [Currency.BTC]: {
-    address: address(Currency.BTC),
-    transaction: transaction(Currency.BTC),
-    wallet: wallet(Currency.BTC),
-    key: key(Currency.BTC)
-  },
-  [Currency.BTG]: {
-    address: address(Currency.BTG),
-    transaction: transaction(Currency.BTG),
-    wallet: wallet(Currency.BTG),
-    key: key(Currency.BTG)
+export default (backendApiUrl: string) => {
+  return {
+    user: user(backendApiUrl),
+    transfers,
+    config,
+    constants,
+    crypto,
+    [Currency.BTC]: {
+      address: address(backendApiUrl, Currency.BTC),
+      transaction: transaction(backendApiUrl, Currency.BTC),
+      wallet: wallet(backendApiUrl, Currency.BTC),
+      key: key(backendApiUrl, Currency.BTC)
+    },
+    [Currency.BTG]: {
+      address: address(backendApiUrl, Currency.BTG),
+      transaction: transaction(backendApiUrl, Currency.BTG),
+      wallet: wallet(backendApiUrl, Currency.BTG),
+      key: key(backendApiUrl, Currency.BTG)
+    }
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,6 @@ export default async (backendApiUrl: string) => {
     user: user(backendApi),
     transfers,
     config,
-    constants,
     crypto,
     [Currency.BTC]: creatCurrencyModule(btcBackendApi, btcOps),
     [Currency.BTG]: creatCurrencyModule(btgBackendApi, btgOps),
@@ -45,4 +44,5 @@ function creatCurrencyModule(backendApi: backendApiFactory.CurrencyBackendApi, b
 
 
 export { Currency } from './types/domain'
+export { constants }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,28 +9,40 @@ import user from './lib/user'
 import * as transfers from './lib/transfers'
 import * as config from './lib/config'
 import { Currency } from "./types/domain";
+import bitcoinOps from './lib/bitcoin'
+import { BitcoinOperations } from './lib/bitcoin-operations';
 
 export default async (backendApiUrl: string) => {
-  const chainInfo = await backendApiFactory.create(backendApiUrl)
+  const backendApi = backendApiFactory.create(backendApiUrl)
+  const chainInfo = await backendApi.chainInfo()
+
+  const btcBackendApi = backendApiFactory.withCurrency(backendApiUrl, Currency.BTC)
+  const btcOps = bitcoinOps(Currency.BTC, chainInfo.chain)
+
+  const btgBackendApi = backendApiFactory.withCurrency(backendApiUrl, Currency.BTG)
+  const btgOps = bitcoinOps(Currency.BTG, chainInfo.chain)
+
   return {
-    user: user(backendApiUrl),
+    user: user(backendApi),
     transfers,
     config,
     constants,
     crypto,
-    [Currency.BTC]: {
-      address: address(backendApiUrl, Currency.BTC),
-      transaction: transaction(backendApiUrl, Currency.BTC),
-      wallet: wallet(backendApiUrl, Currency.BTC),
-      key: key(backendApiUrl, Currency.BTC)
-    },
-    [Currency.BTG]: {
-      address: address(backendApiUrl, Currency.BTG),
-      transaction: transaction(backendApiUrl, Currency.BTG),
-      wallet: wallet(backendApiUrl, Currency.BTG),
-      key: key(backendApiUrl, Currency.BTG)
-    }
+    [Currency.BTC]: creatCurrencyModule(btcBackendApi, btcOps),
+    [Currency.BTG]: creatCurrencyModule(btgBackendApi, btgOps),
   }
 }
 
+function creatCurrencyModule(backendApi: backendApiFactory.CurrencyBackendApi, bitcoinOps: BitcoinOperations) {
+  const keyModule = key(backendApi, bitcoinOps)
+  return {
+    address: address(backendApi, bitcoinOps, keyModule),
+    transaction: transaction(backendApi, keyModule, bitcoinOps),
+    wallet: wallet(backendApi, keyModule),
+    key: keyModule
+  };
+}
+
+
 export { Currency } from './types/domain'
+

--- a/src/lib/address.ts
+++ b/src/lib/address.ts
@@ -1,20 +1,16 @@
-import { Currency } from "../types/domain";
-import * as backendApiFactory from './backend-api'
-import bitcoinFactory from './bitcoin'
-import keyFactory from './key'
+import { KeyModule } from './key'
+import { CurrencyBackendApi } from "./backend-api";
+import { BitcoinOperations } from "./bitcoin-operations";
 
-export default (backendApiUrl: string, currency: Currency, btcNetwork: string) => {
-  const backendApi = backendApiFactory.withCurrency(backendApiUrl, currency)
-  const bitcoin = bitcoinFactory(currency, btcNetwork)
-  const keyApi = keyFactory(backendApiUrl, currency, btcNetwork)
+export default (backendApi: CurrencyBackendApi, bitcoinOps: BitcoinOperations, keyModule: KeyModule) => {
 
   const generateNewMultisigAddress = (rootKeys: String[], path: string): any => {
     const derivedKeys = rootKeys.map((rootKey: string) => {
-      return keyApi.deriveKey(rootKey, path).neutered().toBase58()
+      return keyModule.deriveKey(rootKey, path).neutered().toBase58()
     })
 
-    const redeemScript = bitcoin.createMultisigRedeemScript(derivedKeys)
-    const address = bitcoin.redeemScriptToAddress(redeemScript)
+    const redeemScript = bitcoinOps.createMultisigRedeemScript(derivedKeys)
+    const address = bitcoinOps.redeemScriptToAddress(redeemScript)
 
     return { address, redeemScript }
   }

--- a/src/lib/address.ts
+++ b/src/lib/address.ts
@@ -3,10 +3,10 @@ import * as backendApiFactory from './backend-api'
 import bitcoinFactory from './bitcoin'
 import keyFactory from './key'
 
-export default (backendApiUrl: string, currency: Currency) => {
+export default (backendApiUrl: string, currency: Currency, btcNetwork: string) => {
   const backendApi = backendApiFactory.withCurrency(backendApiUrl, currency)
-  const bitcoin = bitcoinFactory(currency)
-  const keyApi = keyFactory(backendApiUrl, currency)
+  const bitcoin = bitcoinFactory(currency, btcNetwork)
+  const keyApi = keyFactory(backendApiUrl, currency, btcNetwork)
 
   const generateNewMultisigAddress = (rootKeys: String[], path: string): any => {
     const derivedKeys = rootKeys.map((rootKey: string) => {

--- a/src/lib/address.ts
+++ b/src/lib/address.ts
@@ -3,10 +3,10 @@ import * as backendApiFactory from './backend-api'
 import bitcoinFactory from './bitcoin'
 import keyFactory from './key'
 
-export default (currency: Currency) => {
-  const backendApi = backendApiFactory.withCurrency(currency)
+export default (backendApiUrl: string, currency: Currency) => {
+  const backendApi = backendApiFactory.withCurrency(backendApiUrl, currency)
   const bitcoin = bitcoinFactory(currency)
-  const keyApi = keyFactory(currency)
+  const keyApi = keyFactory(backendApiUrl, currency)
 
   const generateNewMultisigAddress = (rootKeys: String[], path: string): any => {
     const derivedKeys = rootKeys.map((rootKey: string) => {

--- a/src/lib/backend-api.ts
+++ b/src/lib/backend-api.ts
@@ -22,10 +22,27 @@ import {
   MontlySummaryBackendResponse,
   SetupPasswordBackendResponse,
   ListTransfersBackendResponse,
-  ChainInfoResponse
+  ChainInfoResponse as ChainModeResponse
 } from 'response'
 import request from './utils/request'
 import { Currency } from "../types/domain";
+
+export interface SakiewkaBackend {
+  core: BaseBackendApi,
+  [Currency.BTC]: CurrencyBackendApi,
+  [Currency.BTG]: CurrencyBackendApi
+}
+
+export const backendFactory = (backendApiUrl: string): SakiewkaBackend => {
+  const backendApi = create(backendApiUrl)
+  const btcBackendApi = withCurrency(backendApiUrl, Currency.BTC)
+  const btgBackendApi = withCurrency(backendApiUrl, Currency.BTG)
+  return {
+    core: backendApi,
+    [Currency.BTC]: btcBackendApi,
+    [Currency.BTG]: btgBackendApi
+  }
+}
 
 export interface BaseBackendApi {
   login(login: string, password: string, codeIn?: number): Promise<LoginBackendResponse>
@@ -37,7 +54,7 @@ export interface BaseBackendApi {
   info(token: string): Promise<InfoBackendResponse>
   monthlySummary(token: string, month: number, year: number, fiatCurrency: number): Promise<MontlySummaryBackendResponse>
   listTransfers(token: string, walletId: string, limit: number, nextPageToken?: string): Promise<ListTransfersBackendResponse>
-  chainInfo(): Promise<ChainInfoResponse>
+  chainNetworkType(): Promise<ChainModeResponse>
 }
 
 export const create = (backendApiUrl: string): BaseBackendApi => {
@@ -161,9 +178,9 @@ export const create = (backendApiUrl: string): BaseBackendApi => {
     return response.data
   }
 
-  const chainInfo = async (): Promise<ChainInfoResponse> => {
+  const chainNetworkType = async (): Promise<ChainModeResponse> => {
     const options = { method: 'GET' }
-    const response = await request(`${backendApiUrl}/chain-info`, options)
+    const response = await request(`${backendApiUrl}/chain-network-type`, options)
     return response.data
   }
 
@@ -177,7 +194,7 @@ export const create = (backendApiUrl: string): BaseBackendApi => {
     info,
     monthlySummary,
     listTransfers,
-    chainInfo
+    chainNetworkType
   }
 }
 

--- a/src/lib/backend-api.ts
+++ b/src/lib/backend-api.ts
@@ -146,6 +146,13 @@ export const create = (backendApiUrl: string) => {
     const response = await request(`${backendApiUrl}/transfers${queryString}`, options)
     return response.data
   }
+
+  const chainInfo = async () => {
+    const options = { method: 'GET' }
+    const response = await request(`${backendApiUrl}/chain-info`, options)
+    return response.data
+  }
+
   return {
     login,
     init2fa,
@@ -155,7 +162,8 @@ export const create = (backendApiUrl: string) => {
     setupPassword,
     info,
     monthlySummary,
-    listTransfers
+    listTransfers,
+    chainInfo
   }
 }
 

--- a/src/lib/backend-api.ts
+++ b/src/lib/backend-api.ts
@@ -26,130 +26,142 @@ import {
 import request from './utils/request'
 import { Currency } from "../types/domain";
 
-
-const getBackendApiUrl = () => process.env.BACKEND_API_URL
-
-// BTC
-// user
-export const login = async (login: string, password: string, codeIn?: number): Promise<LoginBackendResponse> => {
-  const options = {
-    method: 'POST',
-    body: JSON.stringify({
-      password,
-      email: login,
-      code: codeIn
-    })
-  }
-  const response = await request(`${getBackendApiUrl()}/user/login`, options)
-  return response.data
-}
-
-export const init2fa = async (token: string, password: string): Promise<Init2faBackendResponse> => {
-  const options = {
-    method: 'POST',
-    headers: {
-      Authorization: token
-    },
-    body: JSON.stringify({ password })
-  }
-  const response = await request(`${getBackendApiUrl()}/user/2fa/init`, options)
-  return response.data
-}
-
-export const confirm2fa = async (token: string, password: string, code: number): Promise<Confirm2faBackendResponse> => {
-  const options = {
-    method: 'POST',
-    headers: {
-      Authorization: token
-    },
-    body: JSON.stringify({ password, code })
-  }
-  const response = await request(`${getBackendApiUrl()}/user/2fa/confirm`, options)
-  return response.data
-}
-
-export const disable2fa = async (token: string, password: string, code: number): Promise<Disable2faBackendResponse> => {
-  const options = {
-    method: 'POST',
-    headers: {
-      Authorization: token
-    },
-    body: JSON.stringify({ password, code })
-  }
-  const response = await request(`${getBackendApiUrl()}/user/2fa/disable`, options)
-  return response.data
-}
-
-export const register = async (login: string): Promise<RegisterBackendResponse> => {
-  const options = {
-    method: 'POST',
-    body: JSON.stringify({
-      email: login
-    })
-  }
-
-  const response = await request(`${getBackendApiUrl()}/user/register`, options)
-  return response.data
-}
-
-export const setupPassword = async (token: string, password: String): Promise<SetupPasswordBackendResponse> => {
-  const options = {
-    method: 'POST',
-    headers: {
-      Authorization: token
-    },
-    body: JSON.stringify({
-      password
-    })
-  }
-  const response = await request(`${getBackendApiUrl()}/user/setup-password`, options)
-  return response.data
-}
-
-export const info = async (token: string): Promise<InfoBackendResponse> => {
-  const options = {
-    method: 'GET',
-    headers: {
-      Authorization: token
+export const create = (backendApiUrl: string) => {
+  // BTC
+  // user
+  const login = async (login: string, password: string, codeIn?: number): Promise<LoginBackendResponse> => {
+    const options = {
+      method: 'POST',
+      body: JSON.stringify({
+        password,
+        email: login,
+        code: codeIn
+      })
     }
+    const response = await request(`${backendApiUrl}/user/login`, options)
+    return response.data
   }
 
-  const response = await request(`${getBackendApiUrl()}/user/info`, options)
-  return response.data
-}
-
-export const monthlySummary = async (token: string, month: number, year: number, fiatCurrency: number): Promise<MontlySummaryBackendResponse> => {
-  const options = {
-    method: 'GET',
-    headers: {
-      Authorization: token
+  const init2fa = async (token: string, password: string): Promise<Init2faBackendResponse> => {
+    const options = {
+      method: 'POST',
+      headers: {
+        Authorization: token
+      },
+      body: JSON.stringify({ password })
     }
+    const response = await request(`${backendApiUrl}/user/2fa/init`, options)
+    return response.data
   }
 
-  const response = await request(`${getBackendApiUrl()}/transfers/monthly-summary/${month}/${year}/${fiatCurrency}`, options)
-  return response.data
-}
-
-export const listTransfers = async (token: string,
-                                    walletId: string,
-                                    limit: number,
-                                    nextPageToken?: string): Promise<ListTransfersBackendResponse> => {
-  const options = {
-    method: 'GET',
-    headers: {
-      Authorization: token
+  const confirm2fa = async (token: string, password: string, code: number): Promise<Confirm2faBackendResponse> => {
+    const options = {
+      method: 'POST',
+      headers: {
+        Authorization: token
+      },
+      body: JSON.stringify({ password, code })
     }
+    const response = await request(`${backendApiUrl}/user/2fa/confirm`, options)
+    return response.data
   }
 
-  const nextPageParam = nextPageToken ? `&nextPageToken=${nextPageToken}` : ''
-  const walletIdParam = walletId ? `&walletId=${walletId}` : ''
-  const queryString = `?limit=${limit}${nextPageParam}${walletIdParam}`
+  const disable2fa = async (token: string, password: string, code: number): Promise<Disable2faBackendResponse> => {
+    const options = {
+      method: 'POST',
+      headers: {
+        Authorization: token
+      },
+      body: JSON.stringify({ password, code })
+    }
+    const response = await request(`${backendApiUrl}/user/2fa/disable`, options)
+    return response.data
+  }
 
-  const response = await request(`${getBackendApiUrl()}/transfers${queryString}`, options)
-  return response.data
+  const register = async (login: string): Promise<RegisterBackendResponse> => {
+    const options = {
+      method: 'POST',
+      body: JSON.stringify({
+        email: login
+      })
+    }
+
+    const response = await request(`${backendApiUrl}/user/register`, options)
+    return response.data
+  }
+
+  const setupPassword = async (token: string, password: String): Promise<SetupPasswordBackendResponse> => {
+    const options = {
+      method: 'POST',
+      headers: {
+        Authorization: token
+      },
+      body: JSON.stringify({
+        password
+      })
+    }
+    const response = await request(`${backendApiUrl}/user/setup-password`, options)
+    return response.data
+  }
+
+  const info = async (token: string): Promise<InfoBackendResponse> => {
+    const options = {
+      method: 'GET',
+      headers: {
+        Authorization: token
+      }
+    }
+
+    const response = await request(`${backendApiUrl}/user/info`, options)
+    return response.data
+  }
+
+  const monthlySummary = async (token: string, month: number, year: number, fiatCurrency: number): Promise<MontlySummaryBackendResponse> => {
+    const options = {
+      method: 'GET',
+      headers: {
+        Authorization: token
+      }
+    }
+
+    const response = await request(`${backendApiUrl}/transfers/monthly-summary/${month}/${year}/${fiatCurrency}`, options)
+    return response.data
+  }
+
+  const listTransfers = async (token: string,
+    walletId: string,
+    limit: number,
+    nextPageToken?: string): Promise<ListTransfersBackendResponse> => {
+    const options = {
+      method: 'GET',
+      headers: {
+        Authorization: token
+      }
+    }
+
+    const nextPageParam = nextPageToken ? `&nextPageToken=${nextPageToken}` : ''
+    const walletIdParam = walletId ? `&walletId=${walletId}` : ''
+    const queryString = `?limit=${limit}${nextPageParam}${walletIdParam}`
+
+    const response = await request(`${backendApiUrl}/transfers${queryString}`, options)
+    return response.data
+  }
+  return {
+    login,
+    init2fa,
+    confirm2fa,
+    disable2fa,
+    register,
+    setupPassword,
+    info,
+    monthlySummary,
+    listTransfers
+  }
 }
 
-export const withCurrency = (currency: Currency) => {
+export const withCurrency = (backendApiUrl: string, currency: Currency) => {
+
+  const baseApi = create(backendApiUrl)
   // wallet
   const createWallet = async (
     token: string,
@@ -165,7 +177,7 @@ export const withCurrency = (currency: Currency) => {
       })
     }
 
-    const response = await request(`${getBackendApiUrl()}/${currency}/wallet`, options)
+    const response = await request(`${backendApiUrl}/${currency}/wallet`, options)
     return response.data
   }
 
@@ -180,7 +192,7 @@ export const withCurrency = (currency: Currency) => {
       }
     }
 
-    const response = await request(`${getBackendApiUrl()}/${currency}/wallet/${walletId}`, options)
+    const response = await request(`${backendApiUrl}/${currency}/wallet/${walletId}`, options)
     return response.data
   }
 
@@ -198,7 +210,7 @@ export const withCurrency = (currency: Currency) => {
 
     const queryString = `limit=${limit}${nextPageToken ? `&nextPageToken=${nextPageToken}` : ''}`
 
-    const response = await request(`${getBackendApiUrl()}/${currency}/wallet?${queryString}`, options)
+    const response = await request(`${backendApiUrl}/${currency}/wallet?${queryString}`, options)
     return response.data
   }
 
@@ -213,7 +225,7 @@ export const withCurrency = (currency: Currency) => {
       }
     }
 
-    const response = await request(`${getBackendApiUrl()}/${currency}/wallet/${walletId}/balance`, options)
+    const response = await request(`${backendApiUrl}/${currency}/wallet/${walletId}/balance`, options)
     return response.data
   }
 
@@ -229,7 +241,7 @@ export const withCurrency = (currency: Currency) => {
       })
     }
 
-    const response = await request(`${getBackendApiUrl()}/${currency}/wallet/${walletId}/address?change=${change}`, options)
+    const response = await request(`${backendApiUrl}/${currency}/wallet/${walletId}/address?change=${change}`, options)
     return response.data
   }
 
@@ -241,7 +253,7 @@ export const withCurrency = (currency: Currency) => {
       }
     }
 
-    const response = await request(`${getBackendApiUrl()}/${currency}/wallet/${walletId}/address/${address}`, options)
+    const response = await request(`${backendApiUrl}/${currency}/wallet/${walletId}/address/${address}`, options)
     return response.data
   }
 
@@ -260,7 +272,7 @@ export const withCurrency = (currency: Currency) => {
 
     const queryString = `limit=${limit}${nextPageToken ? `&nextPageToken=${nextPageToken}` : ''}`
 
-    const response = await request(`${getBackendApiUrl()}/${currency}/wallet/${walletId}/address?${queryString}`, options)
+    const response = await request(`${backendApiUrl}/${currency}/wallet/${walletId}/address?${queryString}`, options)
     return response.data
   }
 
@@ -275,7 +287,7 @@ export const withCurrency = (currency: Currency) => {
       })
     }
 
-    const response = await request(`${getBackendApiUrl()}/${currency}/wallet/${walletId}/utxo`, options)
+    const response = await request(`${backendApiUrl}/${currency}/wallet/${walletId}/utxo`, options)
     return response.data
   }
 
@@ -291,7 +303,7 @@ export const withCurrency = (currency: Currency) => {
       })
     }
 
-    const response = await request(`${getBackendApiUrl()}/${currency}/wallet/${walletId}/send`, options)
+    const response = await request(`${backendApiUrl}/${currency}/wallet/${walletId}/send`, options)
     return response.data
   }
 
@@ -307,7 +319,7 @@ export const withCurrency = (currency: Currency) => {
       }
     }
 
-    const response = await request(`${getBackendApiUrl()}/${currency}/key/${keyId}${includePrivate ? `?includePrivate=${includePrivate}` : ''}`, options)
+    const response = await request(`${backendApiUrl}/${currency}/key/${keyId}${includePrivate ? `?includePrivate=${includePrivate}` : ''}`, options)
     return response.data
   }
 
@@ -319,18 +331,17 @@ export const withCurrency = (currency: Currency) => {
       }
     }
 
-    const response = await request(`${getBackendApiUrl()}/${currency}/wallet/${walletId}/max-transfer-amount?recipient=${params.recipient}&feeRate=${params.feeRate}`, options)
+    const response = await request(`${backendApiUrl}/${currency}/wallet/${walletId}/max-transfer-amount?recipient=${params.recipient}&feeRate=${params.feeRate}`, options)
     return response.data
   }
 
   const getFeesRates = async (): Promise<GetFeesRates> => {
-    const response = await request(`${getBackendApiUrl()}/${currency}/fees`, { method: 'GET' })
+    const response = await request(`${backendApiUrl}/${currency}/fees`, { method: 'GET' })
     return response.data
   }
 
 
   return {
-    confirm2fa,
     createNewAddress,
     createWallet,
     getAddress,
@@ -342,15 +353,7 @@ export const withCurrency = (currency: Currency) => {
     listWallets,
     sendTransaction,
     getFeesRates,
-    disable2fa,
-    getBackendApiUrl,
-    info,
-    init2fa,
-    listTransfers,
-    login,
     maxTransferAmount,
-    monthlySummary,
-    register,
-    setupPassword
+    ...baseApi
   }
 }

--- a/src/lib/bitcoin-operations.ts
+++ b/src/lib/bitcoin-operations.ts
@@ -7,10 +7,8 @@ import {
   In,
 } from 'bitcoinjs-lib'
 import bip69 from 'bip69'
-import { UTXO, Recipient, Path, TxOut, Currency } from '../types/domain'
+import { UTXO, Recipient, Path, TxOut } from '../types/domain'
 import { BigNumber } from "bignumber.js";
-import { networkFactory } from "./config";
-
 
 const btcjsToUtxo = (input: UTXO_btcjs): UTXO => {
   return {
@@ -39,15 +37,14 @@ interface UTXO_btcjs {
 
 export class BitcoinOperations {
   protected bitcoinLib: any
-  protected currency: Currency
-  protected btcNetwork: string
+  protected network : any
 
-  constructor(btcNetwork: string) {
-    this.btcNetwork = btcNetwork
+  constructor(network: any) {
+    this.network = network
   }
 
   private base58ToKeyBuffer = (key: string): Buffer => {
-    return this.bitcoinLib.HDNode.fromBase58(key, networkFactory(this.btcNetwork, this.currency)).getPublicKeyBuffer()
+    return this.bitcoinLib.HDNode.fromBase58(key, this.network ).getPublicKeyBuffer()
   }
 
   createMultisigRedeemScript = (base58Keys: string[]): Buffer => {
@@ -63,19 +60,19 @@ export class BitcoinOperations {
 
   redeemScriptToAddress = (redeemScript: Buffer): string => {
     const scriptPubKey = this.multisigRedeemScriptToScriptPubKey(redeemScript)
-    return this.bitcoinLib.address.fromOutputScript(scriptPubKey, networkFactory(this.btcNetwork, this.currency))
+    return this.bitcoinLib.address.fromOutputScript(scriptPubKey, this.network)
   }
 
   outputScriptToAddress = (outputScript: Buffer): string => {
-    return this.bitcoinLib.address.fromOutputScript(outputScript, networkFactory(this.btcNetwork, this.currency))
+    return this.bitcoinLib.address.fromOutputScript(outputScript, this.network)
   }
 
   base58ToECPair = (base58Key: string): ECPair => {
-    return this.bitcoinLib.HDNode.fromBase58(base58Key, networkFactory(this.btcNetwork, this.currency)).keyPair
+    return this.bitcoinLib.HDNode.fromBase58(base58Key, this.network).keyPair
   }
 
   base58ToHDNode = (base58Key: string): HDNode => {
-    return this.bitcoinLib.HDNode.fromBase58(base58Key, networkFactory(this.btcNetwork, this.currency))
+    return this.bitcoinLib.HDNode.fromBase58(base58Key, this.network)
   }
 
   hdNodeToBase58Pub = (node: HDNode): string => {
@@ -87,7 +84,7 @@ export class BitcoinOperations {
   }
 
   seedBufferToHDNode = (seedBuffer: Buffer): HDNode => {
-    return this.bitcoinLib.HDNode.fromSeedBuffer(seedBuffer, networkFactory(this.btcNetwork, this.currency))
+    return this.bitcoinLib.HDNode.fromSeedBuffer(seedBuffer, this.network)
   }
 
   txFromHex = (transactionHex: string): Transaction => {
@@ -95,7 +92,7 @@ export class BitcoinOperations {
   }
 
   addressToOutputScript = (address: string): Buffer => {
-    return this.bitcoinLib.address.toOutputScript(address, networkFactory(this.btcNetwork, this.currency))
+    return this.bitcoinLib.address.toOutputScript(address, this.network)
   }
 
   decodeTxOutput = (output: Out): Recipient => ({

--- a/src/lib/bitcoin-operations.ts
+++ b/src/lib/bitcoin-operations.ts
@@ -38,11 +38,16 @@ interface UTXO_btcjs {
 }
 
 export class BitcoinOperations {
-  protected bitcoinLib : any
-  protected currency : Currency
+  protected bitcoinLib: any
+  protected currency: Currency
+  protected btcNetwork: string
+
+  constructor(btcNetwork: string) {
+    this.btcNetwork = btcNetwork
+  }
 
   private base58ToKeyBuffer = (key: string): Buffer => {
-    return this.bitcoinLib.HDNode.fromBase58(key, networkFactory(this.currency)).getPublicKeyBuffer()
+    return this.bitcoinLib.HDNode.fromBase58(key, networkFactory(this.btcNetwork, this.currency)).getPublicKeyBuffer()
   }
 
   createMultisigRedeemScript = (base58Keys: string[]): Buffer => {
@@ -58,19 +63,19 @@ export class BitcoinOperations {
 
   redeemScriptToAddress = (redeemScript: Buffer): string => {
     const scriptPubKey = this.multisigRedeemScriptToScriptPubKey(redeemScript)
-    return this.bitcoinLib.address.fromOutputScript(scriptPubKey, networkFactory(this.currency))
+    return this.bitcoinLib.address.fromOutputScript(scriptPubKey, networkFactory(this.btcNetwork, this.currency))
   }
 
   outputScriptToAddress = (outputScript: Buffer): string => {
-    return this.bitcoinLib.address.fromOutputScript(outputScript, networkFactory(this.currency))
+    return this.bitcoinLib.address.fromOutputScript(outputScript, networkFactory(this.btcNetwork, this.currency))
   }
 
   base58ToECPair = (base58Key: string): ECPair => {
-    return this.bitcoinLib.HDNode.fromBase58(base58Key, networkFactory(this.currency)).keyPair
+    return this.bitcoinLib.HDNode.fromBase58(base58Key, networkFactory(this.btcNetwork, this.currency)).keyPair
   }
 
   base58ToHDNode = (base58Key: string): HDNode => {
-    return this.bitcoinLib.HDNode.fromBase58(base58Key, networkFactory(this.currency))
+    return this.bitcoinLib.HDNode.fromBase58(base58Key, networkFactory(this.btcNetwork, this.currency))
   }
 
   hdNodeToBase58Pub = (node: HDNode): string => {
@@ -82,7 +87,7 @@ export class BitcoinOperations {
   }
 
   seedBufferToHDNode = (seedBuffer: Buffer): HDNode => {
-    return this.bitcoinLib.HDNode.fromSeedBuffer(seedBuffer, networkFactory(this.currency))
+    return this.bitcoinLib.HDNode.fromSeedBuffer(seedBuffer, networkFactory(this.btcNetwork, this.currency))
   }
 
   txFromHex = (transactionHex: string): Transaction => {
@@ -90,7 +95,7 @@ export class BitcoinOperations {
   }
 
   addressToOutputScript = (address: string): Buffer => {
-    return this.bitcoinLib.address.toOutputScript(address, networkFactory(this.currency))
+    return this.bitcoinLib.address.toOutputScript(address, networkFactory(this.btcNetwork, this.currency))
   }
 
   decodeTxOutput = (output: Out): Recipient => ({
@@ -120,9 +125,9 @@ export class BitcoinOperations {
       .map(tx => ({ script: tx.script, value: new BigNumber(tx.value) }))
   }
 
-  initializeTxBuilder : () => TransactionBuilder
+  initializeTxBuilder: () => TransactionBuilder
 
-  txBuilderFromTx : (tx: Transaction) => TransactionBuilder
+  txBuilderFromTx: (tx: Transaction) => TransactionBuilder
 
-  sign : (txb:TransactionBuilder,idx:number,signingKey:ECPair,amount?:BigNumber,redeemScript?:Buffer) => void
+  sign: (txb: TransactionBuilder, idx: number, signingKey: ECPair, amount?: BigNumber, redeemScript?: Buffer) => void
 }

--- a/src/lib/bitcoin.ts
+++ b/src/lib/bitcoin.ts
@@ -2,12 +2,13 @@ import { Currency } from '../types/domain'
 import BtgOperations from './btg-operations'
 import BtcOperations from "./btc-operations";
 import { BitcoinOperations } from "./bitcoin-operations";
+import { networkFactory } from './config';
 
 export default (currency: Currency, btcNetwork: string): BitcoinOperations => {
   if (currency == Currency.BTC) {
-    return new BtcOperations(btcNetwork)
+    return new BtcOperations(networkFactory(btcNetwork, currency))
   } else if (currency == Currency.BTG) {
-    return new BtgOperations(btcNetwork)
+    return new BtgOperations(networkFactory(btcNetwork, currency))
   } else {
     throw new Error(`No bitcoin operations for ${currency}`)
   }

--- a/src/lib/bitcoin.ts
+++ b/src/lib/bitcoin.ts
@@ -3,14 +3,11 @@ import BtgOperations from './btg-operations'
 import BtcOperations from "./btc-operations";
 import { BitcoinOperations } from "./bitcoin-operations";
 
-const btgOperations = new BtgOperations()
-const btcOperations = new BtcOperations()
-
-export default (currency:Currency) : BitcoinOperations => {
-  if(currency == Currency.BTC) {
-    return btcOperations
-  } else if(currency == Currency.BTG) {
-    return btgOperations
+export default (currency: Currency, btcNetwork: string): BitcoinOperations => {
+  if (currency == Currency.BTC) {
+    return new BtcOperations(btcNetwork)
+  } else if (currency == Currency.BTG) {
+    return new BtgOperations(btcNetwork)
   } else {
     throw new Error(`No bitcoin operations for ${currency}`)
   }

--- a/src/lib/btc-operations.ts
+++ b/src/lib/btc-operations.ts
@@ -7,18 +7,17 @@ import { Currency } from '../types/domain';
 
 export default class BtcOperations extends BitcoinOperations {
   protected bitcoinLib = btcLib
-  protected currency : Currency = Currency.BTC
+  protected currency: Currency = Currency.BTC
 
-  sign = (txb:TransactionBuilder,idx:number,signingKey:ECPair,amount?:BigNumber,redeemScript?:Buffer) : void => {
-    txb.sign(idx, signingKey,redeemScript)
+  sign = (txb: TransactionBuilder, idx: number, signingKey: ECPair, amount?: BigNumber, redeemScript?: Buffer): void => {
+    txb.sign(idx, signingKey, redeemScript)
   }
 
-
   initializeTxBuilder = (): TransactionBuilder => {
-    return new this.bitcoinLib.TransactionBuilder(networkFactory(this.currency))
+    return new this.bitcoinLib.TransactionBuilder(networkFactory(this.btcNetwork, this.currency))
   }
 
   txBuilderFromTx = (tx: Transaction): TransactionBuilder => {
-    return btcLib.TransactionBuilder.fromTransaction(tx, networkFactory(this.currency))
+    return btcLib.TransactionBuilder.fromTransaction(tx, networkFactory(this.btcNetwork, this.currency))
   }
 }

--- a/src/lib/btc-operations.ts
+++ b/src/lib/btc-operations.ts
@@ -1,7 +1,6 @@
 import * as btcLib from 'bitcoinjs-lib'
 import { ECPair, Transaction, TransactionBuilder } from 'bitcoinjs-lib'
 import { BitcoinOperations } from "./bitcoin-operations";
-import { networkFactory } from "./config";
 import { BigNumber } from "bignumber.js";
 import { Currency } from '../types/domain';
 
@@ -14,10 +13,10 @@ export default class BtcOperations extends BitcoinOperations {
   }
 
   initializeTxBuilder = (): TransactionBuilder => {
-    return new this.bitcoinLib.TransactionBuilder(networkFactory(this.btcNetwork, this.currency))
+    return new this.bitcoinLib.TransactionBuilder(this.network)
   }
 
   txBuilderFromTx = (tx: Transaction): TransactionBuilder => {
-    return btcLib.TransactionBuilder.fromTransaction(tx, networkFactory(this.btcNetwork, this.currency))
+    return btcLib.TransactionBuilder.fromTransaction(tx, this.network)
   }
 }

--- a/src/lib/btg-operations.ts
+++ b/src/lib/btg-operations.ts
@@ -9,16 +9,15 @@ import { Currency } from '../types/domain';
 
 export default class BtgOperations extends BitcoinOperations {
   protected bitcoinLib = btgLib
-  protected currency : Currency = Currency.BTG
+  protected currency: Currency = Currency.BTG
 
-  sign = (txb:TransactionBuilder,idx:number,signingKey:ECPair,amount?:BigNumber,redeemScript?:Buffer) : void => {
+  sign = (txb: TransactionBuilder, idx: number, signingKey: ECPair, amount?: BigNumber, redeemScript?: Buffer): void => {
     const hashType = Transaction.SIGHASH_ALL | Transaction.SIGHASH_FORKID
     txb.sign(idx, signingKey, redeemScript, hashType, btcToSatoshi(amount).toNumber())
   }
 
-
   initializeTxBuilder = (): TransactionBuilder => {
-    const txb = new this.bitcoinLib.TransactionBuilder(networkFactory(this.currency))
+    const txb = new this.bitcoinLib.TransactionBuilder(networkFactory(this.btcNetwork, this.currency))
     txb.setVersion(2)
     txb.enableBitcoinGold(true)
     return txb
@@ -26,6 +25,6 @@ export default class BtgOperations extends BitcoinOperations {
 
   txBuilderFromTx = (tx: Transaction): TransactionBuilder => {
     const forkid = Transaction.FORKID_BTG;
-    return btgLib.TransactionBuilder.fromTransaction(tx, networkFactory(this.currency), forkid)
+    return btgLib.TransactionBuilder.fromTransaction(tx, networkFactory(this.btcNetwork, this.currency), forkid)
   }
 }

--- a/src/lib/btg-operations.ts
+++ b/src/lib/btg-operations.ts
@@ -1,11 +1,9 @@
 import * as btgLib from 'bgoldjs-lib'
 import { Transaction, TransactionBuilder, ECPair } from "bgoldjs-lib";
 import { BitcoinOperations } from "./bitcoin-operations";
-import { networkFactory } from "./config";
 import { btcToSatoshi } from "./utils/helpers";
 import BigNumber from "bignumber.js";
 import { Currency } from '../types/domain';
-
 
 export default class BtgOperations extends BitcoinOperations {
   protected bitcoinLib = btgLib
@@ -17,7 +15,7 @@ export default class BtgOperations extends BitcoinOperations {
   }
 
   initializeTxBuilder = (): TransactionBuilder => {
-    const txb = new this.bitcoinLib.TransactionBuilder(networkFactory(this.btcNetwork, this.currency))
+    const txb = new this.bitcoinLib.TransactionBuilder(this.network)
     txb.setVersion(2)
     txb.enableBitcoinGold(true)
     return txb
@@ -25,6 +23,6 @@ export default class BtgOperations extends BitcoinOperations {
 
   txBuilderFromTx = (tx: Transaction): TransactionBuilder => {
     const forkid = Transaction.FORKID_BTG;
-    return btgLib.TransactionBuilder.fromTransaction(tx, networkFactory(this.btcNetwork, this.currency), forkid)
+    return btgLib.TransactionBuilder.fromTransaction(tx, this.network, forkid)
   }
 }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,11 +1,10 @@
 import { SUPPORTED_NETWORKS } from './constants'
 import { Currency } from '../types/domain';
 
-export const networkFactory = (currency : Currency) => {
-  const envNetwork = (process.env.BTC_NETWORK || 'mainnet').toLowerCase();
-  const network = SUPPORTED_NETWORKS[currency][envNetwork];
-  if(network == null) {
-    throw new Error(`There is no network for ${currency} and ${envNetwork}`)
+export const networkFactory = (btcNetwork: string, currency: Currency) => {
+  const network = SUPPORTED_NETWORKS[currency][btcNetwork];
+  if (network == null) {
+    throw new Error(`There is no network for ${currency} and ${btcNetwork}`)
   }
   return network
 }

--- a/src/lib/ethereum.ts
+++ b/src/lib/ethereum.ts
@@ -2,83 +2,95 @@ import ethAbi from 'ethereumjs-abi'
 import ethUtil from 'ethereumjs-util'
 
 import bitcoin from './bitcoin'
-import { Currency } from "../types/domain";
-const { base58ToHDNode } = bitcoin(Currency.BTC)
+import { Currency } from "../types/domain"
 
-const OnlyDigits = /^[1-9]+\d*$/
+export default (btcNetwork: string) => {
+  const { base58ToHDNode } = bitcoin(Currency.BTC, btcNetwork)
 
-export const createETHOperationHash = (
-  address: string, value: string, data: string, expireBlock: number, contractNonce: number
-) => {
-  if (!OnlyDigits.test(value)) {
-    throw new Error("Value was not an integer!")
+  const OnlyDigits = /^[1-9]+\d*$/
+
+  const createETHOperationHash = (
+    address: string, value: string, data: string, expireBlock: number, contractNonce: number
+  ) => {
+    if (!OnlyDigits.test(value)) {
+      throw new Error("Value was not an integer!")
+    }
+    return ethUtil.bufferToHex(
+      ethAbi.soliditySHA3(
+        ['string', 'address', 'uint', 'string', 'uint', 'uint'],
+        [
+          'ETHER',
+          new ethUtil.BN(address, 16),
+          value,
+          data,
+          expireBlock,
+          contractNonce
+        ]
+      )
+    )
   }
-  return ethUtil.bufferToHex(
-    ethAbi.soliditySHA3(
-      ['string', 'address', 'uint', 'string', 'uint', 'uint'],
-      [
-        'ETHER',
-        new ethUtil.BN(address, 16),
-        value,
-        data,
-        expireBlock,
-        contractNonce
-      ]
-    )
-  )
-}
 
-export const createTokenOperationHash = (
-  address: string, value: string, contractAddress: string, expireBlock: number, contractNonce: number
-) => {
-  if (!OnlyDigits.test(value)) {
-    throw new Error("Value was not an integer!")
+  const createTokenOperationHash = (
+    address: string, value: string, contractAddress: string, expireBlock: number, contractNonce: number
+  ) => {
+    if (!OnlyDigits.test(value)) {
+      throw new Error("Value was not an integer!")
+    }
+    return ethUtil.bufferToHex(
+      ethAbi.soliditySHA3(
+        ['string', 'address', 'uint', 'address', 'uint', 'uint'],
+        [
+          'ERC20',
+          new ethUtil.BN(address, 16),
+          value,
+          new ethUtil.BN(contractAddress, 16),
+          expireBlock,
+          contractNonce
+        ]
+      )
+    )
   }
-  return ethUtil.bufferToHex(
-    ethAbi.soliditySHA3(
-      ['string', 'address', 'uint', 'address', 'uint', 'uint'],
-      [
-        'ERC20',
-        new ethUtil.BN(address, 16),
-        value,
-        new ethUtil.BN(contractAddress, 16),
-        expireBlock,
-        contractNonce
-      ]
+
+  const createGenericOperationHash = (
+    types: string[], values: any[]
+  ) => {
+    return ethUtil.bufferToHex(
+      ethAbi.soliditySHA3(
+        types,
+        values.map((elem: any, index: number) => {
+          if (types[index] === 'address') {
+            return new ethUtil.BN(elem.toString(), 16)
+          } else return elem
+        })
+      )
     )
-  )
-}
+  }
 
-export const createGenericOperationHash = (
-  types: string[], values: any[]
-) => {
-  return ethUtil.bufferToHex(
-    ethAbi.soliditySHA3(
-      types,
-      values.map((elem: any, index: number) => {
-        if (types[index] === 'address') {
-          return new ethUtil.BN(elem.toString(), 16)
-        } else return elem
-      })
+  const createSignature = (operationHash: string, prvKey: string) => {
+    const signatureInParts = ethUtil.ecsign(
+      new Buffer(ethUtil.stripHexPrefix(operationHash), 'hex'),
+      new Buffer(prvKey, 'hex')
     )
-  )
+
+    const r = ethUtil.setLengthLeft(signatureInParts.r, 32).toString('hex')
+    const s = ethUtil.setLengthLeft(signatureInParts.s, 32).toString('hex')
+    const v = ethUtil.stripHexPrefix(ethUtil.intToHex(signatureInParts.v, 32))
+
+    return ethUtil.addHexPrefix(r.concat(s, v))
+  }
+
+  const xprvToEthPrivateKey = (xprv: string) => {
+    const hdNode = base58ToHDNode(xprv)
+    const ethPrvKey = new Buffer(hdNode.keyPair.d.toHex(), 'hex')
+    return ethUtil.setLengthLeft(ethPrvKey, 32).toString('hex')
+  }
+
+  return {
+    createSignature,
+    xprvToEthPrivateKey,
+    createGenericOperationHash,
+    createTokenOperationHash,
+    createETHOperationHash
+  }
 }
 
-export const createSignature = (operationHash: string, prvKey: string) => {
-  const signatureInParts = ethUtil.ecsign(
-    new Buffer(ethUtil.stripHexPrefix(operationHash), 'hex'),
-    new Buffer(prvKey, 'hex')
-  )
-
-  const r = ethUtil.setLengthLeft(signatureInParts.r, 32).toString('hex')
-  const s = ethUtil.setLengthLeft(signatureInParts.s, 32).toString('hex')
-  const v = ethUtil.stripHexPrefix(ethUtil.intToHex(signatureInParts.v, 32))
-
-  return ethUtil.addHexPrefix(r.concat(s, v))
-}
-
-export const xprvToEthPrivateKey = (xprv: string) => {
-  const hdNode = base58ToHDNode(xprv)
-  const ethPrvKey = new Buffer(hdNode.keyPair.d.toHex(), 'hex')
-  return ethUtil.setLengthLeft(ethPrvKey, 32).toString('hex')
-}

--- a/src/lib/key.ts
+++ b/src/lib/key.ts
@@ -5,9 +5,9 @@ import bitcoinFactory from './bitcoin'
 import * as backendApiFactory from './backend-api'
 
 
-export default (backendApiUrl:string, currency: Currency) => {
+export default (backendApiUrl:string, currency: Currency, btcNetwork: string) => {
   const backendApi = backendApiFactory.withCurrency(backendApiUrl, currency)
-  const bitcoin = bitcoinFactory(currency)
+  const bitcoin = bitcoinFactory(currency, btcNetwork)
 
   const generateNewKeyPair = (
     path?: string

--- a/src/lib/key.ts
+++ b/src/lib/key.ts
@@ -10,10 +10,13 @@ export interface KeyModule {
   encryptKeyPair(keyPair: KeyPair, passphrase: string): KeyPair
   deriveKeyPair(keyPair: KeyPair, path: string): KeyPair
   deriveKey(rootKey: string, path: string): HDNode
+}
+
+export interface KeyApi {
   getKey(userToken: string, keyId: string, includePrivate?: boolean): Promise<GetKeyBackendResponse>
 }
 
-export default (backendApi: CurrencyBackendApi, bitcoin: BitcoinOperations): KeyModule => {
+export const keyModuleFactory = (bitcoin: BitcoinOperations): KeyModule => {
   const generateNewKeyPair = (
     path?: string
   ): KeyPair => {
@@ -58,12 +61,14 @@ export default (backendApi: CurrencyBackendApi, bitcoin: BitcoinOperations): Key
     if (path === '') return node
     return node.derivePath(path)
   }
+  return { generateNewKeyPair, encryptKeyPair, deriveKeyPair, deriveKey }
+}
 
+export const keyApiFactory = (backendApi: CurrencyBackendApi): KeyApi => {
   const getKey = (
     userToken: string,
     keyId: string,
     includePrivate?: boolean
   ): Promise<GetKeyBackendResponse> => backendApi.getKey(userToken, keyId, includePrivate)
-
-  return { generateNewKeyPair, encryptKeyPair, deriveKeyPair, deriveKey, getKey }
+  return { getKey }
 }

--- a/src/lib/key.ts
+++ b/src/lib/key.ts
@@ -1,14 +1,19 @@
-import { Currency, KeyPair } from '../types/domain'
+import { KeyPair } from '../types/domain'
 import { getRandomBytes, encrypt } from './crypto'
 import { HDNode } from 'bitcoinjs-lib'
-import bitcoinFactory from './bitcoin'
-import * as backendApiFactory from './backend-api'
+import { CurrencyBackendApi } from './backend-api';
+import { BitcoinOperations } from './bitcoin-operations';
+import { GetKeyBackendResponse } from 'response';
 
+export interface KeyModule {
+  generateNewKeyPair(path?: string): KeyPair
+  encryptKeyPair(keyPair: KeyPair, passphrase: string): KeyPair
+  deriveKeyPair(keyPair: KeyPair, path: string): KeyPair
+  deriveKey(rootKey: string, path: string): HDNode
+  getKey(userToken: string, keyId: string, includePrivate?: boolean): Promise<GetKeyBackendResponse>
+}
 
-export default (backendApiUrl:string, currency: Currency, btcNetwork: string) => {
-  const backendApi = backendApiFactory.withCurrency(backendApiUrl, currency)
-  const bitcoin = bitcoinFactory(currency, btcNetwork)
-
+export default (backendApi: CurrencyBackendApi, bitcoin: BitcoinOperations): KeyModule => {
   const generateNewKeyPair = (
     path?: string
   ): KeyPair => {
@@ -58,8 +63,7 @@ export default (backendApiUrl:string, currency: Currency, btcNetwork: string) =>
     userToken: string,
     keyId: string,
     includePrivate?: boolean
-  ) => backendApi.getKey(userToken, keyId, includePrivate)
+  ): Promise<GetKeyBackendResponse> => backendApi.getKey(userToken, keyId, includePrivate)
 
   return { generateNewKeyPair, encryptKeyPair, deriveKeyPair, deriveKey, getKey }
-
 }

--- a/src/lib/key.ts
+++ b/src/lib/key.ts
@@ -5,8 +5,8 @@ import bitcoinFactory from './bitcoin'
 import * as backendApiFactory from './backend-api'
 
 
-export default (currency: Currency) => {
-  const backendApi = backendApiFactory.withCurrency(currency)
+export default (backendApiUrl:string, currency: Currency) => {
+  const backendApi = backendApiFactory.withCurrency(backendApiUrl, currency)
   const bitcoin = bitcoinFactory(currency)
 
   const generateNewKeyPair = (

--- a/src/lib/tests/address.test.ts
+++ b/src/lib/tests/address.test.ts
@@ -3,7 +3,7 @@ import { expect } from 'chai'
 import { currency } from './helpers'
 import addressModuleFactory from '../address'
 
-const addressModule = addressModuleFactory(currency)
+const addressModule = addressModuleFactory('https://backendApiUrl', currency)
 import * as config from '../config'
 import { SUPPORTED_NETWORKS } from "../constants";
 import { Currency } from "../../types/domain";

--- a/src/lib/tests/address.test.ts
+++ b/src/lib/tests/address.test.ts
@@ -55,18 +55,17 @@ describe('generateNewMultisigAddress', () => {
 })
 
 describe('createNewAddress', () => {
-  const addressModule = addressApiFactory(backendApi)
+  const addressApi = addressApiFactory(backendApi)
   it('should exist', () => {
-    expect(addressModule.createNewAddress).to.be.a('function')
+    expect(addressApi.createNewAddress).to.be.a('function')
   })
 
   it('should accept 2 arguments and pass them backend-api method and return result of its call', async () => {
     // @ts-ignore
     const mockImplementation = jest.fn(() => 'backend response')
-    // @ts-ignore
     backendApi.createNewAddress = mockImplementation
 
-    const res = await addressModule.createNewAddress('testToken', 'abcd')
+    const res = await addressApi.createNewAddress('testToken', 'abcd')
 
     const [token, walletId, isChange, name] = mockImplementation.mock.calls[0]
     expect(token).to.eq('testToken')
@@ -79,10 +78,9 @@ describe('createNewAddress', () => {
   it('should accept 3 arguments and pass them backend-api method and return result of its call', async () => {
     // @ts-ignore
     const mockImplementation = jest.fn(() => 'backend response')
-    // @ts-ignore
     backendApi.createNewAddress = mockImplementation
 
-    const res = await addressModule.createNewAddress('testToken', 'abcd', 'testName')
+    const res = await addressApi.createNewAddress('testToken', 'abcd', 'testName')
 
     const [token, walletId, isChange, name] = mockImplementation.mock.calls[0]
     expect(token).to.eq('testToken')
@@ -103,7 +101,6 @@ describe('getAddress', () => {
   it('should pass proper arguments to backend-api method and return result of its call', async () => {
     // @ts-ignore
     const mockImplementation = jest.fn(() => 'backend response')
-    // @ts-ignore
     backendApi.getAddress = mockImplementation
 
     const res = await addressModule.getAddress('testToken', 'abcd', 'testAddress')
@@ -126,7 +123,6 @@ describe('listAddresses', () => {
   it('should pass proper arguments to backend-api method and return result of its call', async () => {
     // @ts-ignore
     const mockImplementation = jest.fn(() => 'backend response')
-    // @ts-ignore
     backendApi.listAddresses = mockImplementation
 
     const res = await addressModule.listAddresses('testToken', 'testWalletId', 101, 'testNextPageToken')

--- a/src/lib/tests/address.test.ts
+++ b/src/lib/tests/address.test.ts
@@ -3,22 +3,17 @@ import { expect } from 'chai'
 import { currency } from './helpers'
 import addressModuleFactory from '../address'
 
-const addressModule = addressModuleFactory('https://backendApiUrl', currency)
-import * as config from '../config'
-import { SUPPORTED_NETWORKS } from "../constants";
 import { Currency } from "../../types/domain";
-
-beforeEach(() => {
-  // @ts-ignore
-  config.networkFactory = (c: Currency) => SUPPORTED_NETWORKS[c].mainnet
-})
 
 describe('generateNewMultisigAddress', () => {
   it('should exist', () => {
+    const addressModule = addressModuleFactory('https://backendApiUrl', currency, 'mainnet')
     expect(addressModule.generateNewMultisigAddress).to.be.a('function')
   })
 
   it('should return proper address', () => {
+    const addressModule = addressModuleFactory('https://backendApiUrl', currency, 'mainnet')
+
     const pubKeys = [
       'xpub661MyMwAqRbcEbQrpBDMTDgW5Hjg5BFxoJD2SnzTmTASPxD4i4j1xMCKojYwgaRXXBRAHB7WPECxA2aQVfL61G4mWjnHMj6BJtAQKMVAiYs',
       'xpub661MyMwAqRbcGukLdXtbs5TTqkddNUYzdWAmZ3mQTRZgtaySzU9ePfVEZWtQJBZGbfKfhPZfG74z6TXkeEx2atofMhn2n4bHLzjDWHREM5u',
@@ -34,8 +29,7 @@ describe('generateNewMultisigAddress', () => {
   })
 
   it('should return proper testnet address', () => {
-    // @ts-ignore
-    config.networkFactory = (c: Currency) => SUPPORTED_NETWORKS[c].testnet
+    const addressModule = addressModuleFactory('https://backendApiUrl', currency, 'testnet')
     const pubKeys = [
       'tpubD6NzVbkrYhZ4YLQpJAWwxCiNVAH13QSiFHWWTRmocy5zCMN6Nr8fbLVN38Y5nu7KwZ24ux74qotyyNkeF9KN52Gawcjr4ujHkQUDTBmw8Bu',
       'tpubD6NzVbkrYhZ4YWW2LBu48ZLMDtU6YZNug3dArpmhCZVCeRduVLF9FRNaLbwkND5Twf4DS1aXuFqvYd1S4BBTFGwjDM7iy1CK8vuwJHYqpdd',
@@ -52,6 +46,7 @@ describe('generateNewMultisigAddress', () => {
 })
 
 describe('createNewAddress', () => {
+  const addressModule = addressModuleFactory('https://backendApiUrl', currency, 'mainnet')
   it('should exist', () => {
     expect(addressModule.createNewAddress).to.be.a('function')
   })
@@ -88,6 +83,8 @@ describe('createNewAddress', () => {
 })
 
 describe('getAddress', () => {
+  const addressModule = addressModuleFactory('https://backendApiUrl', currency, 'mainnet')
+
   it('should exist', () => {
     expect(addressModule.getAddress).to.be.a('function')
   })
@@ -109,6 +106,8 @@ describe('getAddress', () => {
 })
 
 describe('listAddresses', () => {
+  const addressModule = addressModuleFactory('https://backendApiUrl', currency, 'mainnet')
+
   it('should exist', () => {
     expect(addressModule.listAddresses).to.be.a('function')
   })

--- a/src/lib/tests/address.test.ts
+++ b/src/lib/tests/address.test.ts
@@ -1,9 +1,9 @@
 import { expect } from 'chai'
 
 import { currency } from './helpers'
-import addressModuleFactory from '../address'
+import { addressModuleFactory, addressApiFactory } from '../address'
 import * as backendFactory from '../backend-api'
-import keyFactory from '../key'
+import { keyModuleFactory } from '../key'
 import bitcoinFactory from '../bitcoin'
 import { Currency } from "../../types/domain";
 
@@ -11,15 +11,15 @@ const backendApi = backendFactory.withCurrency('https://backendApiUrl', currency
 describe('generateNewMultisigAddress', () => {
   it('should exist', () => {
     const bitcoin = bitcoinFactory(currency, 'mainnet')
-    const keyModule = keyFactory(backendApi, bitcoin)
-    const addressModule = addressModuleFactory(backendApi, bitcoin, keyModule)
+    const keyModule = keyModuleFactory(bitcoin)
+    const addressModule = addressModuleFactory(bitcoin, keyModule)
     expect(addressModule.generateNewMultisigAddress).to.be.a('function')
   })
 
   it('should return proper address', () => {
     const bitcoin = bitcoinFactory(currency, 'mainnet')
-    const keyModule = keyFactory(backendApi, bitcoin)
-    const addressModule = addressModuleFactory(backendApi, bitcoin, keyModule)
+    const keyModule = keyModuleFactory(bitcoin)
+    const addressModule = addressModuleFactory(bitcoin, keyModule)
 
     const pubKeys = [
       'xpub661MyMwAqRbcEbQrpBDMTDgW5Hjg5BFxoJD2SnzTmTASPxD4i4j1xMCKojYwgaRXXBRAHB7WPECxA2aQVfL61G4mWjnHMj6BJtAQKMVAiYs',
@@ -37,8 +37,8 @@ describe('generateNewMultisigAddress', () => {
 
   it('should return proper testnet address', () => {
     const bitcoin = bitcoinFactory(currency, 'testnet')
-    const keyModule = keyFactory(backendApi, bitcoin)
-    const addressModule = addressModuleFactory(backendApi, bitcoin, keyModule)
+    const keyModule = keyModuleFactory(bitcoin)
+    const addressModule = addressModuleFactory(bitcoin, keyModule)
     const pubKeys = [
       'tpubD6NzVbkrYhZ4YLQpJAWwxCiNVAH13QSiFHWWTRmocy5zCMN6Nr8fbLVN38Y5nu7KwZ24ux74qotyyNkeF9KN52Gawcjr4ujHkQUDTBmw8Bu',
       'tpubD6NzVbkrYhZ4YWW2LBu48ZLMDtU6YZNug3dArpmhCZVCeRduVLF9FRNaLbwkND5Twf4DS1aXuFqvYd1S4BBTFGwjDM7iy1CK8vuwJHYqpdd',
@@ -55,9 +55,7 @@ describe('generateNewMultisigAddress', () => {
 })
 
 describe('createNewAddress', () => {
-  const bitcoin = bitcoinFactory(currency, 'mainnet')
-  const keyModule = keyFactory(backendApi, bitcoin)
-  const addressModule = addressModuleFactory(backendApi, bitcoin, keyModule)
+  const addressModule = addressApiFactory(backendApi)
   it('should exist', () => {
     expect(addressModule.createNewAddress).to.be.a('function')
   })
@@ -86,7 +84,7 @@ describe('createNewAddress', () => {
 
     const res = await addressModule.createNewAddress('testToken', 'abcd', 'testName')
 
-    const [token, walletId,isChange, name] = mockImplementation.mock.calls[0]
+    const [token, walletId, isChange, name] = mockImplementation.mock.calls[0]
     expect(token).to.eq('testToken')
     expect(walletId).to.eq('abcd')
     expect(isChange).to.eq(false)
@@ -96,9 +94,7 @@ describe('createNewAddress', () => {
 })
 
 describe('getAddress', () => {
-  const bitcoin = bitcoinFactory(currency, 'mainnet')
-  const keyModule = keyFactory(backendApi, bitcoin)
-  const addressModule = addressModuleFactory(backendApi, bitcoin, keyModule)
+  const addressModule = addressApiFactory(backendApi)
 
   it('should exist', () => {
     expect(addressModule.getAddress).to.be.a('function')
@@ -121,9 +117,7 @@ describe('getAddress', () => {
 })
 
 describe('listAddresses', () => {
-  const bitcoin = bitcoinFactory(currency, 'mainnet')
-  const keyModule = keyFactory(backendApi, bitcoin)
-  const addressModule = addressModuleFactory(backendApi, bitcoin, keyModule)
+  const addressModule = addressApiFactory(backendApi)
 
   it('should exist', () => {
     expect(addressModule.listAddresses).to.be.a('function')

--- a/src/lib/tests/address.test.ts
+++ b/src/lib/tests/address.test.ts
@@ -2,17 +2,24 @@ import { expect } from 'chai'
 
 import { currency } from './helpers'
 import addressModuleFactory from '../address'
-
+import * as backendFactory from '../backend-api'
+import keyFactory from '../key'
+import bitcoinFactory from '../bitcoin'
 import { Currency } from "../../types/domain";
 
+const backendApi = backendFactory.withCurrency('https://backendApiUrl', currency)
 describe('generateNewMultisigAddress', () => {
   it('should exist', () => {
-    const addressModule = addressModuleFactory('https://backendApiUrl', currency, 'mainnet')
+    const bitcoin = bitcoinFactory(currency, 'mainnet')
+    const keyModule = keyFactory(backendApi, bitcoin)
+    const addressModule = addressModuleFactory(backendApi, bitcoin, keyModule)
     expect(addressModule.generateNewMultisigAddress).to.be.a('function')
   })
 
   it('should return proper address', () => {
-    const addressModule = addressModuleFactory('https://backendApiUrl', currency, 'mainnet')
+    const bitcoin = bitcoinFactory(currency, 'mainnet')
+    const keyModule = keyFactory(backendApi, bitcoin)
+    const addressModule = addressModuleFactory(backendApi, bitcoin, keyModule)
 
     const pubKeys = [
       'xpub661MyMwAqRbcEbQrpBDMTDgW5Hjg5BFxoJD2SnzTmTASPxD4i4j1xMCKojYwgaRXXBRAHB7WPECxA2aQVfL61G4mWjnHMj6BJtAQKMVAiYs',
@@ -29,7 +36,9 @@ describe('generateNewMultisigAddress', () => {
   })
 
   it('should return proper testnet address', () => {
-    const addressModule = addressModuleFactory('https://backendApiUrl', currency, 'testnet')
+    const bitcoin = bitcoinFactory(currency, 'testnet')
+    const keyModule = keyFactory(backendApi, bitcoin)
+    const addressModule = addressModuleFactory(backendApi, bitcoin, keyModule)
     const pubKeys = [
       'tpubD6NzVbkrYhZ4YLQpJAWwxCiNVAH13QSiFHWWTRmocy5zCMN6Nr8fbLVN38Y5nu7KwZ24ux74qotyyNkeF9KN52Gawcjr4ujHkQUDTBmw8Bu',
       'tpubD6NzVbkrYhZ4YWW2LBu48ZLMDtU6YZNug3dArpmhCZVCeRduVLF9FRNaLbwkND5Twf4DS1aXuFqvYd1S4BBTFGwjDM7iy1CK8vuwJHYqpdd',
@@ -46,7 +55,9 @@ describe('generateNewMultisigAddress', () => {
 })
 
 describe('createNewAddress', () => {
-  const addressModule = addressModuleFactory('https://backendApiUrl', currency, 'mainnet')
+  const bitcoin = bitcoinFactory(currency, 'mainnet')
+  const keyModule = keyFactory(backendApi, bitcoin)
+  const addressModule = addressModuleFactory(backendApi, bitcoin, keyModule)
   it('should exist', () => {
     expect(addressModule.createNewAddress).to.be.a('function')
   })
@@ -55,13 +66,14 @@ describe('createNewAddress', () => {
     // @ts-ignore
     const mockImplementation = jest.fn(() => 'backend response')
     // @ts-ignore
-    addressModule.createNewAddress = mockImplementation
+    backendApi.createNewAddress = mockImplementation
 
     const res = await addressModule.createNewAddress('testToken', 'abcd')
 
-    const [token, walletId, name] = mockImplementation.mock.calls[0]
+    const [token, walletId, isChange, name] = mockImplementation.mock.calls[0]
     expect(token).to.eq('testToken')
     expect(walletId).to.eq('abcd')
+    expect(isChange).to.eq(false)
     expect(name).to.eq(undefined)
     expect(res).to.eq('backend response')
   })
@@ -70,20 +82,23 @@ describe('createNewAddress', () => {
     // @ts-ignore
     const mockImplementation = jest.fn(() => 'backend response')
     // @ts-ignore
-    addressModule.createNewAddress = mockImplementation
+    backendApi.createNewAddress = mockImplementation
 
     const res = await addressModule.createNewAddress('testToken', 'abcd', 'testName')
 
-    const [token, walletId, name] = mockImplementation.mock.calls[0]
+    const [token, walletId,isChange, name] = mockImplementation.mock.calls[0]
     expect(token).to.eq('testToken')
     expect(walletId).to.eq('abcd')
+    expect(isChange).to.eq(false)
     expect(name).to.eq('testName')
     expect(res).to.eq('backend response')
   })
 })
 
 describe('getAddress', () => {
-  const addressModule = addressModuleFactory('https://backendApiUrl', currency, 'mainnet')
+  const bitcoin = bitcoinFactory(currency, 'mainnet')
+  const keyModule = keyFactory(backendApi, bitcoin)
+  const addressModule = addressModuleFactory(backendApi, bitcoin, keyModule)
 
   it('should exist', () => {
     expect(addressModule.getAddress).to.be.a('function')
@@ -93,7 +108,7 @@ describe('getAddress', () => {
     // @ts-ignore
     const mockImplementation = jest.fn(() => 'backend response')
     // @ts-ignore
-    addressModule.getAddress = mockImplementation
+    backendApi.getAddress = mockImplementation
 
     const res = await addressModule.getAddress('testToken', 'abcd', 'testAddress')
 
@@ -106,7 +121,9 @@ describe('getAddress', () => {
 })
 
 describe('listAddresses', () => {
-  const addressModule = addressModuleFactory('https://backendApiUrl', currency, 'mainnet')
+  const bitcoin = bitcoinFactory(currency, 'mainnet')
+  const keyModule = keyFactory(backendApi, bitcoin)
+  const addressModule = addressModuleFactory(backendApi, bitcoin, keyModule)
 
   it('should exist', () => {
     expect(addressModule.listAddresses).to.be.a('function')
@@ -116,7 +133,7 @@ describe('listAddresses', () => {
     // @ts-ignore
     const mockImplementation = jest.fn(() => 'backend response')
     // @ts-ignore
-    addressModule.listAddresses = mockImplementation
+    backendApi.listAddresses = mockImplementation
 
     const res = await addressModule.listAddresses('testToken', 'testWalletId', 101, 'testNextPageToken')
 

--- a/src/lib/tests/backend-api.test.ts
+++ b/src/lib/tests/backend-api.test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai'
 
 import { currency } from './helpers'
 import * as apiFactory from '../backend-api'
-const api  = apiFactory.withCurrency(currency)
+const api  = apiFactory.withCurrency('backurl/api/v1', currency)
 import * as request from '../utils/request'
 import { MaxTransferAmountParams } from 'response';
 
@@ -15,8 +15,6 @@ beforeEach(() => {
   // @ts-ignore
   mockImplementation.mockClear()
 })
-
-process.env.BACKEND_API_URL = 'backurl/api/v1'
 
 describe('login', () => {
   it('should exist', () => {

--- a/src/lib/tests/backend-api.test.ts
+++ b/src/lib/tests/backend-api.test.ts
@@ -2,6 +2,7 @@ import { expect } from 'chai'
 
 import { currency } from './helpers'
 import * as apiFactory from '../backend-api'
+const baseApi = apiFactory.create('backurl/api/v1')
 const api  = apiFactory.withCurrency('backurl/api/v1', currency)
 import * as request from '../utils/request'
 import { MaxTransferAmountParams } from 'response';
@@ -18,11 +19,11 @@ beforeEach(() => {
 
 describe('login', () => {
   it('should exist', () => {
-    expect(api.login).to.be.a('function')
+    expect(baseApi.login).to.be.a('function')
   })
 
   it('should send proper request', async () => {
-    await api.login('a', 'b')
+    await baseApi.login('a', 'b')
 
     const [url, params] = mockImplementation.mock.calls[0]
     const reqBody = JSON.parse(params.body)
@@ -35,7 +36,7 @@ describe('login', () => {
   })
 
   it('should send request with 2fa code', async () => {
-    await api.login('a', 'b', 123456)
+    await baseApi.login('a', 'b', 123456)
 
     const [url, params] = mockImplementation.mock.calls[0]
     const reqBody = JSON.parse(params.body)
@@ -50,11 +51,11 @@ describe('login', () => {
 
 describe('init2fa', () => {
   it('should exist', () => {
-    expect(api.init2fa).to.be.a('function')
+    expect(baseApi.init2fa).to.be.a('function')
   })
 
   it('should send proper request', async () => {
-    await api.init2fa('testToken', 'password')
+    await baseApi.init2fa('testToken', 'password')
 
     const [url, params] = mockImplementation.mock.calls[0]
     const reqBody = JSON.parse(params.body)
@@ -67,11 +68,11 @@ describe('init2fa', () => {
 
 describe('confirm2fa', () => {
   it('should exist', () => {
-    expect(api.confirm2fa).to.be.a('function')
+    expect(baseApi.confirm2fa).to.be.a('function')
   })
 
   it('should send proper request', async () => {
-    await api.confirm2fa('testToken', 'password', 101202)
+    await baseApi.confirm2fa('testToken', 'password', 101202)
 
     const [url, params] = mockImplementation.mock.calls[0]
     const reqBody = JSON.parse(params.body)
@@ -85,11 +86,11 @@ describe('confirm2fa', () => {
 
 describe('disable2fa', () => {
   it('should exist', () => {
-    expect(api.disable2fa).to.be.a('function')
+    expect(baseApi.disable2fa).to.be.a('function')
   })
 
   it('should send proper request', async () => {
-    await api.disable2fa('testToken', 'password', 112233)
+    await baseApi.disable2fa('testToken', 'password', 112233)
 
     const [url, params] = mockImplementation.mock.calls[0]
     const reqBody = JSON.parse(params.body)
@@ -103,11 +104,11 @@ describe('disable2fa', () => {
 
 describe('register', () => {
   it('should exist', () => {
-    expect(api.register).to.be.a('function')
+    expect(baseApi.register).to.be.a('function')
   })
 
   it('should send proper request', async () => {
-    await api.register('a')
+    await baseApi.register('a')
 
     const [url, params] = mockImplementation.mock.calls[0]
     const reqBody = JSON.parse(params.body)
@@ -120,11 +121,11 @@ describe('register', () => {
 
 describe('info', () => {
   it('should exist', () => {
-    expect(api.info).to.be.a('function')
+    expect(baseApi.info).to.be.a('function')
   })
 
   it('should send proper request', async () => {
-    await api.info('testToken')
+    await baseApi.info('testToken')
 
     const [url, params] = mockImplementation.mock.calls[0]
 
@@ -222,7 +223,7 @@ describe('createNewAddress', () => {
   })
 
   it('should send proper request without name param', async () => {
-    await api.createNewAddress('testToken', 'walletId')
+    await api.createNewAddress('testToken', 'walletId', false)
 
     const [url, params] = mockImplementation.mock.calls[0]
     const reqBody = JSON.parse(params.body)
@@ -376,11 +377,11 @@ describe('maxTransferAmount', () => {
 
 describe('setupPassword', () => {
   it('should exist', () => {
-    expect(api.setupPassword).to.be.a('function')
+    expect(baseApi.setupPassword).to.be.a('function')
   })
 
   it('should send proper request', async () => {
-    await api.setupPassword('testToken', 'secret')
+    await baseApi.setupPassword('testToken', 'secret')
 
     const [url, params] = mockImplementation.mock.calls[0]
     const reqBody = JSON.parse(params.body)

--- a/src/lib/tests/backend-stub.ts
+++ b/src/lib/tests/backend-stub.ts
@@ -4,7 +4,7 @@ import { GetKeyBackendResponse } from 'response';
 import { currency } from './helpers'
 
 export const stubGetWallet = (userKeyPair: KeyPair, backupKeyPair: KeyPair, serviceKeyPair: KeyPair) => {
-  const backendApi = backendApiFactory.withCurrency(currency);
+  const backendApi = backendApiFactory.withCurrency("http://backendApiUrl", currency)
   // @ts-ignore
   backendApi.getWallet = jest.fn(() => {
     return Promise.resolve({
@@ -20,7 +20,7 @@ export const stubGetWallet = (userKeyPair: KeyPair, backupKeyPair: KeyPair, serv
 }
 
 export const stubUnspents = (unspents: any) => {
-  const backendApi = backendApiFactory.withCurrency(currency);
+  const backendApi = backendApiFactory.withCurrency("http://backendApiUrl", currency)
   // @ts-ignore
   backendApi.listUnspents = jest.fn(() => {
     return Promise.resolve(unspents)
@@ -30,7 +30,7 @@ export const stubUnspents = (unspents: any) => {
 }
 
 export const stubSendTx = () => {
-  const backendApi = backendApiFactory.withCurrency(currency);
+  const backendApi = backendApiFactory.withCurrency("http://backendApiUrl", currency)
   // @ts-ignore
   const sendTxMock = jest.fn(() => {
     return Promise.resolve(true)
@@ -51,7 +51,7 @@ export const createPath = (cosigner: number, change: number, address: number) =>
 }
 
 export const stubCreateAddress = (address: string) => {
-  const backendApi = backendApiFactory.withCurrency(currency);
+  const backendApi = backendApiFactory.withCurrency("http://backendApiUrl", currency)
   // @ts-ignore
   backendApi.createNewAddress = jest.fn(() => {
     return Promise.resolve({
@@ -63,7 +63,7 @@ export const stubCreateAddress = (address: string) => {
 }
 
 export const stubFeesRates = (recommended: number) => {
-  const backendApi = backendApiFactory.withCurrency(currency);
+  const backendApi = backendApiFactory.withCurrency("http://backendApiUrl", currency)
   // @ts-ignore
   backendApi.getFeesRates = jest.fn(() => {
     return Promise.resolve({ recommended: recommended })
@@ -73,7 +73,7 @@ export const stubFeesRates = (recommended: number) => {
 }
 
 export const stubGetKey = (response: GetKeyBackendResponse) => {
-  const backendApi = backendApiFactory.withCurrency(currency);
+  const backendApi = backendApiFactory.withCurrency("http://backendApiUrl", currency)
 
   // @ts-ignore
   const mockImplementation = jest.fn(() => response)

--- a/src/lib/tests/backend-stub.ts
+++ b/src/lib/tests/backend-stub.ts
@@ -1,10 +1,8 @@
-import * as backendApiFactory from '../backend-api'
 import { KeyPair, KeyType } from '../../types/domain';
 import { GetKeyBackendResponse } from 'response';
-import { currency } from './helpers'
+import { CurrencyBackendApi } from '../backend-api';
 
-export const stubGetWallet = (userKeyPair: KeyPair, backupKeyPair: KeyPair, serviceKeyPair: KeyPair) => {
-  const backendApi = backendApiFactory.withCurrency("http://backendApiUrl", currency)
+export const stubGetWallet = (backendApi: CurrencyBackendApi, userKeyPair: KeyPair, backupKeyPair: KeyPair, serviceKeyPair: KeyPair) => {
   // @ts-ignore
   backendApi.getWallet = jest.fn(() => {
     return Promise.resolve({
@@ -15,30 +13,22 @@ export const stubGetWallet = (userKeyPair: KeyPair, backupKeyPair: KeyPair, serv
       ]
     })
   })
-  // @ts-ignore
-  backendApiFactory.withCurrency = (currency) => backendApi
 }
 
-export const stubUnspents = (unspents: any) => {
-  const backendApi = backendApiFactory.withCurrency("http://backendApiUrl", currency)
+export const stubUnspents = (backendApi: CurrencyBackendApi, unspents: any) => {
   // @ts-ignore
   backendApi.listUnspents = jest.fn(() => {
     return Promise.resolve(unspents)
   })
-  // @ts-ignore
-  backendApiFactory.withCurrency = (currency) => backendApi
 }
 
-export const stubSendTx = () => {
-  const backendApi = backendApiFactory.withCurrency("http://backendApiUrl", currency)
+export const stubSendTx = (backendApi: CurrencyBackendApi) => {
   // @ts-ignore
   const sendTxMock = jest.fn(() => {
     return Promise.resolve(true)
   })
   // @ts-ignore
   backendApi.sendTransaction = sendTxMock
-  // @ts-ignore
-  backendApiFactory.withCurrency = (currency) => backendApi
   return sendTxMock
 }
 
@@ -50,35 +40,23 @@ export const createPath = (cosigner: number, change: number, address: number) =>
   }
 }
 
-export const stubCreateAddress = (address: string) => {
-  const backendApi = backendApiFactory.withCurrency("http://backendApiUrl", currency)
+export const stubCreateAddress = (backendApi: CurrencyBackendApi, address: string) => {
   // @ts-ignore
   backendApi.createNewAddress = jest.fn(() => {
     return Promise.resolve({
       address: address
     })
   })
-  // @ts-ignore
-  backendApiFactory.withCurrency = (currency) => backendApi
 }
 
-export const stubFeesRates = (recommended: number) => {
-  const backendApi = backendApiFactory.withCurrency("http://backendApiUrl", currency)
+export const stubFeesRates = (backendApi: CurrencyBackendApi, recommended: number) => {
   // @ts-ignore
   backendApi.getFeesRates = jest.fn(() => {
     return Promise.resolve({ recommended: recommended })
   })
-  // @ts-ignore
-  backendApiFactory.withCurrency = (currency) => backendApi
 }
 
-export const stubGetKey = (response: GetKeyBackendResponse) => {
-  const backendApi = backendApiFactory.withCurrency("http://backendApiUrl", currency)
-
+export const stubGetKey = (backendApi: CurrencyBackendApi, response: GetKeyBackendResponse) => {
   // @ts-ignore
-  const mockImplementation = jest.fn(() => response)
-  // @ts-ignore
-  backendApi.getKey = mockImplementation
-  // @ts-ignore
-  backendApiFactory.withCurrency = (currency) => backendApi
+  backendApi.getKey = jest.fn(() => response)
 }

--- a/src/lib/tests/bitcoin.test.ts
+++ b/src/lib/tests/bitcoin.test.ts
@@ -3,9 +3,9 @@ import bitcoinFactory from "../bitcoin";
 import { Currency } from "../../types/domain";
 
 describe('btc redeem script', () => {
-  const test = (currency:Currency,key1:string,key2:string,key3:string,expectedResult:string) => {
+  const test = (currency: Currency, key1: string, key2: string, key3: string, expectedResult: string) => {
     it(`should create same ${currency} script regardless of public keys order`, () => {
-      const bitcoin = bitcoinFactory(Currency.BTC)
+      const bitcoin = bitcoinFactory(Currency.BTC, 'mainnet')
       const result1 = bitcoin.createMultisigRedeemScript([key1, key2, key3])
       const result2 = bitcoin.createMultisigRedeemScript([key1, key3, key2])
       const result3 = bitcoin.createMultisigRedeemScript([key2, key1, key3])

--- a/src/lib/tests/create-test-data.test.ts
+++ b/src/lib/tests/create-test-data.test.ts
@@ -4,12 +4,12 @@ import addressModuleFactory from '../address'
 import * as config from '../config'
 import * as constants from '../constants'
 import { Currency } from "../../types/domain";
-const key = keyFactory(currency)
-const addressModule = addressModuleFactory(currency)
+const key = keyFactory("http://backendApiUrl", currency)
+const addressModule = addressModuleFactory("http://backendApiUrl", currency)
 
 beforeEach(() => {
   // @ts-ignore
-  config.networkFactory = (c:Currency) => constants.SUPPORTED_NETWORKS[c].testnet
+  config.networkFactory = (c: Currency) => constants.SUPPORTED_NETWORKS[c].testnet
 })
 
 describe('test data', () => {

--- a/src/lib/tests/create-test-data.test.ts
+++ b/src/lib/tests/create-test-data.test.ts
@@ -1,16 +1,9 @@
 import { currency } from './helpers'
 import keyFactory from '../key'
 import addressModuleFactory from '../address'
-import * as config from '../config'
 import * as constants from '../constants'
-import { Currency } from "../../types/domain";
-const key = keyFactory("http://backendApiUrl", currency)
-const addressModule = addressModuleFactory("http://backendApiUrl", currency)
-
-beforeEach(() => {
-  // @ts-ignore
-  config.networkFactory = (c: Currency) => constants.SUPPORTED_NETWORKS[c].testnet
-})
+const key = keyFactory("http://backendApiUrl", currency, 'testnet')
+const addressModule = addressModuleFactory("http://backendApiUrl", currency, 'testnet')
 
 describe('test data', () => {
   it('should generate a set of keys', () => {

--- a/src/lib/tests/create-test-data.test.ts
+++ b/src/lib/tests/create-test-data.test.ts
@@ -1,9 +1,14 @@
 import { currency } from './helpers'
 import keyFactory from '../key'
+import * as backendFactory from '../backend-api'
 import addressModuleFactory from '../address'
+import bitoinFactory from '../bitcoin'
 import * as constants from '../constants'
-const key = keyFactory("http://backendApiUrl", currency, 'testnet')
-const addressModule = addressModuleFactory("http://backendApiUrl", currency, 'testnet')
+
+const backend = backendFactory.withCurrency("http://backendApiUrl", currency)
+const bitcoin = bitoinFactory(currency, 'testnet')
+const key = keyFactory(backend, bitcoin)
+const addressModule = addressModuleFactory(backend, bitcoin, key)
 
 describe('test data', () => {
   it('should generate a set of keys', () => {

--- a/src/lib/tests/create-test-data.test.ts
+++ b/src/lib/tests/create-test-data.test.ts
@@ -1,14 +1,12 @@
 import { currency } from './helpers'
-import keyFactory from '../key'
-import * as backendFactory from '../backend-api'
-import addressModuleFactory from '../address'
+import { keyModuleFactory } from '../key'
+import { addressModuleFactory } from '../address'
 import bitoinFactory from '../bitcoin'
 import * as constants from '../constants'
 
-const backend = backendFactory.withCurrency("http://backendApiUrl", currency)
 const bitcoin = bitoinFactory(currency, 'testnet')
-const key = keyFactory(backend, bitcoin)
-const addressModule = addressModuleFactory(backend, bitcoin, key)
+const key = keyModuleFactory(bitcoin)
+const addressModule = addressModuleFactory(bitcoin, key)
 
 describe('test data', () => {
   it('should generate a set of keys', () => {

--- a/src/lib/tests/key.test.ts
+++ b/src/lib/tests/key.test.ts
@@ -6,8 +6,8 @@ import keyModuleFactory from '../key'
 import * as config from '../config'
 import { SUPPORTED_NETWORKS } from '../constants'
 
-const backendApi  = backendApiFactory.withCurrency(currency)
-const keyModule = keyModuleFactory(currency)
+const backendApi = backendApiFactory.withCurrency("http://backendApiUrl", currency)
+const keyModule = keyModuleFactory("http://backendApiUrl", currency)
 
 // @ts-ignore
 backendApi.createWallet = jest.fn(() => {
@@ -18,7 +18,7 @@ backendApi.createWallet = jest.fn(() => {
 
 beforeEach(() => {
   // @ts-ignore
-  config.networkFactory = (c : Currency) => SUPPORTED_NETWORKS[c].mainnet
+  config.networkFactory = (c: Currency) => SUPPORTED_NETWORKS[c].mainnet
 })
 
 describe('generateNewKeyPair', () => {
@@ -38,7 +38,7 @@ describe('generateNewKeyPair', () => {
 
   it('should return new testnet keyPair', () => {
     // @ts-ignore
-    config.networkFactory = (c : Currency) => SUPPORTED_NETWORKS[c].testnet
+    config.networkFactory = (c: Currency) => SUPPORTED_NETWORKS[c].testnet
     const result = keyModule.generateNewKeyPair()
 
     expect(result).to.haveOwnProperty('pubKey')
@@ -50,7 +50,7 @@ describe('generateNewKeyPair', () => {
 
   it('should return new regtest keyPair', () => {
     // @ts-ignore
-    config.networkFactory = (c : Currency) => SUPPORTED_NETWORKS[c].regtest
+    config.networkFactory = (c: Currency) => SUPPORTED_NETWORKS[c].regtest
     const result = keyModule.generateNewKeyPair()
 
     expect(result).to.haveOwnProperty('pubKey')
@@ -128,7 +128,7 @@ describe('deriveKey', () => {
 
   it('should create testnet key', () => {
     // @ts-ignore
-    config.networkFactory = (c : Currency) => SUPPORTED_NETWORKS[c].testnet
+    config.networkFactory = (c: Currency) => SUPPORTED_NETWORKS[c].testnet
     const path = `11/20/15`
     const keyPair = keyModule.generateNewKeyPair()
 

--- a/src/lib/tests/key.test.ts
+++ b/src/lib/tests/key.test.ts
@@ -3,11 +3,8 @@ import { expect } from 'chai'
 import { currency } from './helpers'
 import * as backendApiFactory from '../backend-api'
 import keyModuleFactory from '../key'
-import * as config from '../config'
-import { SUPPORTED_NETWORKS } from '../constants'
 
 const backendApi = backendApiFactory.withCurrency("http://backendApiUrl", currency)
-const keyModule = keyModuleFactory("http://backendApiUrl", currency)
 
 // @ts-ignore
 backendApi.createWallet = jest.fn(() => {
@@ -16,17 +13,15 @@ backendApi.createWallet = jest.fn(() => {
   })
 })
 
-beforeEach(() => {
-  // @ts-ignore
-  config.networkFactory = (c: Currency) => SUPPORTED_NETWORKS[c].mainnet
-})
-
 describe('generateNewKeyPair', () => {
+  
   it('should exist', () => {
+    const keyModule = keyModuleFactory("http://backendApiUrl", currency, 'mainnet')
     expect(keyModule.generateNewKeyPair).to.be.a('function')
   })
 
   it('should return new keyPair', () => {
+    const keyModule = keyModuleFactory("http://backendApiUrl", currency, 'mainnet')
     const result = keyModule.generateNewKeyPair()
 
     expect(result).to.haveOwnProperty('pubKey')
@@ -37,8 +32,9 @@ describe('generateNewKeyPair', () => {
   })
 
   it('should return new testnet keyPair', () => {
-    // @ts-ignore
-    config.networkFactory = (c: Currency) => SUPPORTED_NETWORKS[c].testnet
+    const keyModule = keyModuleFactory("http://backendApiUrl", currency, 'testnet')
+
+
     const result = keyModule.generateNewKeyPair()
 
     expect(result).to.haveOwnProperty('pubKey')
@@ -50,7 +46,7 @@ describe('generateNewKeyPair', () => {
 
   it('should return new regtest keyPair', () => {
     // @ts-ignore
-    config.networkFactory = (c: Currency) => SUPPORTED_NETWORKS[c].regtest
+    const keyModule = keyModuleFactory("http://backendApiUrl", currency, 'regtest')
     const result = keyModule.generateNewKeyPair()
 
     expect(result).to.haveOwnProperty('pubKey')
@@ -62,6 +58,7 @@ describe('generateNewKeyPair', () => {
 })
 
 describe('encryptKeyPair', () => {
+  const keyModule = keyModuleFactory("http://backendApiUrl", currency, 'mainnet')
   it('should exist', () => {
     expect(keyModule.encryptKeyPair).to.be.a('function')
   })
@@ -78,10 +75,12 @@ describe('encryptKeyPair', () => {
 
 describe('deriveKey', () => {
   it('should exist', () => {
+    const keyModule = keyModuleFactory("http://backendApiUrl", currency, 'mainnet')
     expect(keyModule.deriveKey).to.be.a('function')
   })
 
   it('should create new hardened key for a given path', () => {
+    const keyModule = keyModuleFactory("http://backendApiUrl", currency, 'mainnet')
     const path = `0'`
     const keyPair = keyModule.generateNewKeyPair()
 
@@ -91,6 +90,7 @@ describe('deriveKey', () => {
   })
 
   it('should create new normal key for a given path', () => {
+    const keyModule = keyModuleFactory("http://backendApiUrl", currency, 'mainnet')
     const path = `11/20/15`
     const keyPair = keyModule.generateNewKeyPair()
 
@@ -101,6 +101,7 @@ describe('deriveKey', () => {
   })
 
   it('should work the same for relative and absolute paths', () => {
+    const keyModule = keyModuleFactory("http://backendApiUrl", currency, 'mainnet')
     const basePath = `m/45'/0`
     const relativePath = '0/0'
 
@@ -127,8 +128,7 @@ describe('deriveKey', () => {
   })
 
   it('should create testnet key', () => {
-    // @ts-ignore
-    config.networkFactory = (c: Currency) => SUPPORTED_NETWORKS[c].testnet
+    const keyModule = keyModuleFactory("http://backendApiUrl", currency, 'testnet')
     const path = `11/20/15`
     const keyPair = keyModule.generateNewKeyPair()
 
@@ -140,6 +140,7 @@ describe('deriveKey', () => {
 })
 
 describe('deriveKeyPair', () => {
+  const keyModule = keyModuleFactory("http://backendApiUrl", currency, 'mainnet')
   it('should exist', () => {
     expect(keyModule.deriveKeyPair).to.be.a('function')
   })
@@ -156,6 +157,7 @@ describe('deriveKeyPair', () => {
 })
 
 describe('getKey', () => {
+  const keyModule = keyModuleFactory("http://backendApiUrl", currency, 'mainnet')
   it('should exist', () => {
     expect(keyModule.getKey).to.be.a('function')
   })

--- a/src/lib/tests/key.test.ts
+++ b/src/lib/tests/key.test.ts
@@ -3,9 +3,9 @@ import { expect } from 'chai'
 import { currency } from './helpers'
 import * as backendApiFactory from '../backend-api'
 import keyModuleFactory from '../key'
+import bitoinFactory from '../bitcoin'
 
 const backendApi = backendApiFactory.withCurrency("http://backendApiUrl", currency)
-
 // @ts-ignore
 backendApi.createWallet = jest.fn(() => {
   return Promise.resolve({
@@ -16,12 +16,15 @@ backendApi.createWallet = jest.fn(() => {
 describe('generateNewKeyPair', () => {
   
   it('should exist', () => {
-    const keyModule = keyModuleFactory("http://backendApiUrl", currency, 'mainnet')
+    const bitcoin = bitoinFactory(currency, 'mainnet')
+    const keyModule = keyModuleFactory(backendApi, bitcoin)
     expect(keyModule.generateNewKeyPair).to.be.a('function')
   })
 
   it('should return new keyPair', () => {
-    const keyModule = keyModuleFactory("http://backendApiUrl", currency, 'mainnet')
+    const bitcoin = bitoinFactory(currency, 'mainnet')
+    const keyModule = keyModuleFactory(backendApi, bitcoin)
+
     const result = keyModule.generateNewKeyPair()
 
     expect(result).to.haveOwnProperty('pubKey')
@@ -32,8 +35,8 @@ describe('generateNewKeyPair', () => {
   })
 
   it('should return new testnet keyPair', () => {
-    const keyModule = keyModuleFactory("http://backendApiUrl", currency, 'testnet')
-
+    const bitcoin = bitoinFactory(currency, 'testnet')
+    const keyModule = keyModuleFactory(backendApi, bitcoin)
 
     const result = keyModule.generateNewKeyPair()
 
@@ -45,8 +48,9 @@ describe('generateNewKeyPair', () => {
   })
 
   it('should return new regtest keyPair', () => {
-    // @ts-ignore
-    const keyModule = keyModuleFactory("http://backendApiUrl", currency, 'regtest')
+    const bitcoin = bitoinFactory(currency, 'regtest')
+    const keyModule = keyModuleFactory(backendApi, bitcoin)
+
     const result = keyModule.generateNewKeyPair()
 
     expect(result).to.haveOwnProperty('pubKey')
@@ -58,7 +62,8 @@ describe('generateNewKeyPair', () => {
 })
 
 describe('encryptKeyPair', () => {
-  const keyModule = keyModuleFactory("http://backendApiUrl", currency, 'mainnet')
+  const bitcoin = bitoinFactory(currency, 'mainnet')
+  const keyModule = keyModuleFactory(backendApi, bitcoin)
   it('should exist', () => {
     expect(keyModule.encryptKeyPair).to.be.a('function')
   })
@@ -75,12 +80,14 @@ describe('encryptKeyPair', () => {
 
 describe('deriveKey', () => {
   it('should exist', () => {
-    const keyModule = keyModuleFactory("http://backendApiUrl", currency, 'mainnet')
+    const bitcoin = bitoinFactory(currency, 'mainnet')
+    const keyModule = keyModuleFactory(backendApi, bitcoin)
     expect(keyModule.deriveKey).to.be.a('function')
   })
 
   it('should create new hardened key for a given path', () => {
-    const keyModule = keyModuleFactory("http://backendApiUrl", currency, 'mainnet')
+    const bitcoin = bitoinFactory(currency, 'mainnet')
+    const keyModule = keyModuleFactory(backendApi, bitcoin)
     const path = `0'`
     const keyPair = keyModule.generateNewKeyPair()
 
@@ -90,7 +97,8 @@ describe('deriveKey', () => {
   })
 
   it('should create new normal key for a given path', () => {
-    const keyModule = keyModuleFactory("http://backendApiUrl", currency, 'mainnet')
+    const bitcoin = bitoinFactory(currency, 'mainnet')
+    const keyModule = keyModuleFactory(backendApi, bitcoin)
     const path = `11/20/15`
     const keyPair = keyModule.generateNewKeyPair()
 
@@ -101,7 +109,8 @@ describe('deriveKey', () => {
   })
 
   it('should work the same for relative and absolute paths', () => {
-    const keyModule = keyModuleFactory("http://backendApiUrl", currency, 'mainnet')
+    const bitcoin = bitoinFactory(currency, 'mainnet')
+    const keyModule = keyModuleFactory(backendApi, bitcoin)
     const basePath = `m/45'/0`
     const relativePath = '0/0'
 
@@ -128,7 +137,8 @@ describe('deriveKey', () => {
   })
 
   it('should create testnet key', () => {
-    const keyModule = keyModuleFactory("http://backendApiUrl", currency, 'testnet')
+    const bitcoin = bitoinFactory(currency, 'testnet')
+    const keyModule = keyModuleFactory(backendApi, bitcoin)
     const path = `11/20/15`
     const keyPair = keyModule.generateNewKeyPair()
 
@@ -140,7 +150,8 @@ describe('deriveKey', () => {
 })
 
 describe('deriveKeyPair', () => {
-  const keyModule = keyModuleFactory("http://backendApiUrl", currency, 'mainnet')
+  const bitcoin = bitoinFactory(currency, 'mainnet')
+  const keyModule = keyModuleFactory(backendApi, bitcoin)
   it('should exist', () => {
     expect(keyModule.deriveKeyPair).to.be.a('function')
   })
@@ -157,7 +168,8 @@ describe('deriveKeyPair', () => {
 })
 
 describe('getKey', () => {
-  const keyModule = keyModuleFactory("http://backendApiUrl", currency, 'mainnet')
+  const bitcoin = bitoinFactory(currency, 'mainnet')
+  const keyModule = keyModuleFactory(backendApi, bitcoin)
   it('should exist', () => {
     expect(keyModule.getKey).to.be.a('function')
   })

--- a/src/lib/tests/key.test.ts
+++ b/src/lib/tests/key.test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai'
 
 import { currency } from './helpers'
 import * as backendApiFactory from '../backend-api'
-import keyModuleFactory from '../key'
+import { keyApiFactory, keyModuleFactory } from '../key'
 import bitoinFactory from '../bitcoin'
 
 const backendApi = backendApiFactory.withCurrency("http://backendApiUrl", currency)
@@ -14,16 +14,16 @@ backendApi.createWallet = jest.fn(() => {
 })
 
 describe('generateNewKeyPair', () => {
-  
+
   it('should exist', () => {
     const bitcoin = bitoinFactory(currency, 'mainnet')
-    const keyModule = keyModuleFactory(backendApi, bitcoin)
+    const keyModule = keyModuleFactory(bitcoin)
     expect(keyModule.generateNewKeyPair).to.be.a('function')
   })
 
   it('should return new keyPair', () => {
     const bitcoin = bitoinFactory(currency, 'mainnet')
-    const keyModule = keyModuleFactory(backendApi, bitcoin)
+    const keyModule = keyModuleFactory(bitcoin)
 
     const result = keyModule.generateNewKeyPair()
 
@@ -36,7 +36,7 @@ describe('generateNewKeyPair', () => {
 
   it('should return new testnet keyPair', () => {
     const bitcoin = bitoinFactory(currency, 'testnet')
-    const keyModule = keyModuleFactory(backendApi, bitcoin)
+    const keyModule = keyModuleFactory(bitcoin)
 
     const result = keyModule.generateNewKeyPair()
 
@@ -49,7 +49,7 @@ describe('generateNewKeyPair', () => {
 
   it('should return new regtest keyPair', () => {
     const bitcoin = bitoinFactory(currency, 'regtest')
-    const keyModule = keyModuleFactory(backendApi, bitcoin)
+    const keyModule = keyModuleFactory(bitcoin)
 
     const result = keyModule.generateNewKeyPair()
 
@@ -63,7 +63,7 @@ describe('generateNewKeyPair', () => {
 
 describe('encryptKeyPair', () => {
   const bitcoin = bitoinFactory(currency, 'mainnet')
-  const keyModule = keyModuleFactory(backendApi, bitcoin)
+  const keyModule = keyModuleFactory(bitcoin)
   it('should exist', () => {
     expect(keyModule.encryptKeyPair).to.be.a('function')
   })
@@ -81,13 +81,13 @@ describe('encryptKeyPair', () => {
 describe('deriveKey', () => {
   it('should exist', () => {
     const bitcoin = bitoinFactory(currency, 'mainnet')
-    const keyModule = keyModuleFactory(backendApi, bitcoin)
+    const keyModule = keyModuleFactory(bitcoin)
     expect(keyModule.deriveKey).to.be.a('function')
   })
 
   it('should create new hardened key for a given path', () => {
     const bitcoin = bitoinFactory(currency, 'mainnet')
-    const keyModule = keyModuleFactory(backendApi, bitcoin)
+    const keyModule = keyModuleFactory(bitcoin)
     const path = `0'`
     const keyPair = keyModule.generateNewKeyPair()
 
@@ -98,7 +98,7 @@ describe('deriveKey', () => {
 
   it('should create new normal key for a given path', () => {
     const bitcoin = bitoinFactory(currency, 'mainnet')
-    const keyModule = keyModuleFactory(backendApi, bitcoin)
+    const keyModule = keyModuleFactory(bitcoin)
     const path = `11/20/15`
     const keyPair = keyModule.generateNewKeyPair()
 
@@ -110,7 +110,7 @@ describe('deriveKey', () => {
 
   it('should work the same for relative and absolute paths', () => {
     const bitcoin = bitoinFactory(currency, 'mainnet')
-    const keyModule = keyModuleFactory(backendApi, bitcoin)
+    const keyModule = keyModuleFactory(bitcoin)
     const basePath = `m/45'/0`
     const relativePath = '0/0'
 
@@ -138,7 +138,7 @@ describe('deriveKey', () => {
 
   it('should create testnet key', () => {
     const bitcoin = bitoinFactory(currency, 'testnet')
-    const keyModule = keyModuleFactory(backendApi, bitcoin)
+    const keyModule = keyModuleFactory(bitcoin)
     const path = `11/20/15`
     const keyPair = keyModule.generateNewKeyPair()
 
@@ -151,7 +151,7 @@ describe('deriveKey', () => {
 
 describe('deriveKeyPair', () => {
   const bitcoin = bitoinFactory(currency, 'mainnet')
-  const keyModule = keyModuleFactory(backendApi, bitcoin)
+  const keyModule = keyModuleFactory(bitcoin)
   it('should exist', () => {
     expect(keyModule.deriveKeyPair).to.be.a('function')
   })
@@ -168,8 +168,7 @@ describe('deriveKeyPair', () => {
 })
 
 describe('getKey', () => {
-  const bitcoin = bitoinFactory(currency, 'mainnet')
-  const keyModule = keyModuleFactory(backendApi, bitcoin)
+  const keyModule = keyApiFactory(backendApi)
   it('should exist', () => {
     expect(keyModule.getKey).to.be.a('function')
   })

--- a/src/lib/tests/transaction-eth.test.ts
+++ b/src/lib/tests/transaction-eth.test.ts
@@ -1,9 +1,9 @@
 import { expect } from 'chai'
 import ethUtil from 'ethereumjs-util'
 
-import * as transaction from '../transaction-eth'
+import transactionFactory from '../transaction-eth'
 import * as backendApi from '../zlevator'
-import { createETHOperationHash, createTokenOperationHash, createGenericOperationHash, createSignature } from '../ethereum'
+import ethereumFactory from '../ethereum'
 
 import { v4 as uuid } from 'uuid';
 import { fail } from 'assert';
@@ -27,11 +27,13 @@ backendApi.sendETH = jest.fn(() => {
 backendApi.sendTokens = jest.fn(() => {
   return Promise.resolve({ tx: '311' })
 })
-
+const transaction = transactionFactory('mainnet')
+const ethereum = ethereumFactory('mainnet')
 const prvKey = '2E63835168223C0D81C152B86C6AE6FFE8EDC63327691953251DCFC6895C96DA'
 const signerAddress = ethUtil.privateToAddress(new Buffer(prvKey, 'hex')).toString('hex')
 
 describe('send ETH', () => {
+
   it('should exist', () => {
     expect(transaction.sendETH).to.be.a('function')
   })
@@ -46,7 +48,7 @@ describe('send ETH', () => {
     // @ts-ignore
     const [, value, expireBlock, contractNonce, , signature] = backendApi.sendETH.mock.calls[0]
 
-    const operationHash = createETHOperationHash(address, value, data, expireBlock, contractNonce)
+    const operationHash = ethereum.createETHOperationHash(address, value, data, expireBlock, contractNonce)
 
     const sigParams = ethUtil.fromRpcSig(signature)
     const pub = ethUtil.ecrecover(
@@ -74,7 +76,7 @@ describe('send Tokens', () => {
     // @ts-ignore
     const [, value, expireBlock, contractNonce, signature] = backendApi.sendTokens.mock.calls[0]
 
-    const operationHash = createTokenOperationHash(address, value, tokenAddress, expireBlock, contractNonce)
+    const operationHash = ethereum.createTokenOperationHash(address, value, tokenAddress, expireBlock, contractNonce)
 
     const sigParams = ethUtil.fromRpcSig(signature)
     const pub = ethUtil.ecrecover(
@@ -94,9 +96,9 @@ describe('sign generic message', () => {
     const txType = "MY_TX"
     const address = '0xa378869a5009b131Ef9c0b300f4049F7bB7091e6'
 
-    const operationHash = createGenericOperationHash(['string', 'address'], [txType, address]);
+    const operationHash = ethereum.createGenericOperationHash(['string', 'address'], [txType, address]);
 
-    const signature = createSignature(operationHash, prvKey)
+    const signature = ethereum.createSignature(operationHash, prvKey)
 
     const sigParams = ethUtil.fromRpcSig(signature)
     const pub = ethUtil.ecrecover(

--- a/src/lib/tests/transaction.test.ts
+++ b/src/lib/tests/transaction.test.ts
@@ -23,11 +23,11 @@ import { Currency, KeyType, UTXO } from '../../types/domain'
 import { currency } from "./helpers";
 import { Transaction } from "bitcoinjs-lib";
 
-const keyModule = keyModuleFactory(currency)
-const addressModule = addressModuleFactory(currency)
+const keyModule = keyModuleFactory("http://backendApiUrl", currency)
+const addressModule = addressModuleFactory("http://backendApiUrl", currency)
 const bitcoinModule = bitcoinModuleFactory(currency)
 
-const transactionModuleWithStubbedApiCalls = () => transactionModuleFactory(currency)
+const transactionModuleWithStubbedApiCalls = () => transactionModuleFactory("http://backendApiUrl", currency)
 const changeAddress = currency == Currency.BTG ? 'ATWyG3xpRdyYy1K6HBdVPBi629W4DNnB9m' : '3DS7Y6bdePdnFCoXqddkevovh4s5M8NhgM'
 const serviceAddress = currency == Currency.BTG ? 'AWu3T7CWXXLxrHwuQ4tnHtubpdp1LHUZUK' : '3AnzyVbVSwfrre3vzQLwVMgZ34HH2Ja22d'
 const destinationAddress = currency == Currency.BTG ? 'Gh6q8MweJFqU5nVuoS8TC4hmPsAJJEtVuA' : '1QFuiEchKQEB1KCcsVULmJMsUhNTDb2PfN'
@@ -39,7 +39,7 @@ const testnetDestinationAddress = '2Mt42Wi2JBbAc6Q4GXsxDWbkDTwaEQhqoEM'
 
 beforeEach(() => {
   // @ts-ignore
-  config.networkFactory = (c : Currency) => SUPPORTED_NETWORKS[c].mainnet
+  config.networkFactory = (c: Currency) => SUPPORTED_NETWORKS[c].mainnet
   use(chaiBigNumber(BigNumber))
   use(chaiAsPromised)
   // mocks
@@ -257,7 +257,7 @@ describe('sendCoins', () => {
       [{
         address: destinationAddress,
         amount: new BigNumber('5')
-      },{
+      }, {
         address,
         amount: new BigNumber('1.99990000')
       }],
@@ -314,7 +314,7 @@ describe('sendCoins', () => {
 
   it('should send coins to testnet', async () => {
     // @ts-ignore
-    config.networkFactory = (c : Currency) => SUPPORTED_NETWORKS[c].testnet
+    config.networkFactory = (c: Currency) => SUPPORTED_NETWORKS[c].testnet
     stubCreateAddress(testnetChangeAddress)
 
     // generates keyPairs and address
@@ -466,7 +466,7 @@ describe('sendCoins', () => {
 
   it('should have only three outputs when api does not return serviceFee details', async () => {
     // @ts-ignore
-    config.networkFactory = (c : Currency) => SUPPORTED_NETWORKS[c].testnet
+    config.networkFactory = (c: Currency) => SUPPORTED_NETWORKS[c].testnet
     stubCreateAddress(testnetChangeAddress)
 
     // generates keyPairs and address
@@ -687,7 +687,7 @@ describe('signTransaction', () => {
 describe('sendCoins and signTransaction', () => {
   it('should send coins to testnet and signTransaction', async () => {
     // @ts-ignore
-    config.networkFactory = (c : Currency) => SUPPORTED_NETWORKS[c].testnet
+    config.networkFactory = (c: Currency) => SUPPORTED_NETWORKS[c].testnet
     stubCreateAddress(testnetChangeAddress)
 
     // generates keyPairs and address

--- a/src/lib/tests/transaction.test.ts
+++ b/src/lib/tests/transaction.test.ts
@@ -4,8 +4,7 @@ import transactionModuleFactory from '../transaction'
 import keyModuleFactory from '../key'
 import addressModuleFactory from '../address'
 import bitcoinModuleFactory from '../bitcoin'
-import * as config from '../config'
-import { ROOT_DERIVATION_PATH, SUPPORTED_NETWORKS, API_ERROR } from '../constants'
+import { ROOT_DERIVATION_PATH, API_ERROR } from '../constants'
 import BigNumber from "bignumber.js";
 import chaiBigNumber from 'chai-bignumber'
 import chaiAsPromised from 'chai-as-promised'
@@ -23,11 +22,6 @@ import { Currency, KeyType, UTXO } from '../../types/domain'
 import { currency } from "./helpers";
 import { Transaction } from "bitcoinjs-lib";
 
-const keyModule = keyModuleFactory("http://backendApiUrl", currency)
-const addressModule = addressModuleFactory("http://backendApiUrl", currency)
-const bitcoinModule = bitcoinModuleFactory(currency)
-
-const transactionModuleWithStubbedApiCalls = () => transactionModuleFactory("http://backendApiUrl", currency)
 const changeAddress = currency == Currency.BTG ? 'ATWyG3xpRdyYy1K6HBdVPBi629W4DNnB9m' : '3DS7Y6bdePdnFCoXqddkevovh4s5M8NhgM'
 const serviceAddress = currency == Currency.BTG ? 'AWu3T7CWXXLxrHwuQ4tnHtubpdp1LHUZUK' : '3AnzyVbVSwfrre3vzQLwVMgZ34HH2Ja22d'
 const destinationAddress = currency == Currency.BTG ? 'Gh6q8MweJFqU5nVuoS8TC4hmPsAJJEtVuA' : '1QFuiEchKQEB1KCcsVULmJMsUhNTDb2PfN'
@@ -39,7 +33,6 @@ const testnetDestinationAddress = '2Mt42Wi2JBbAc6Q4GXsxDWbkDTwaEQhqoEM'
 
 beforeEach(() => {
   // @ts-ignore
-  config.networkFactory = (c: Currency) => SUPPORTED_NETWORKS[c].mainnet
   use(chaiBigNumber(BigNumber))
   use(chaiAsPromised)
   // mocks
@@ -48,6 +41,11 @@ beforeEach(() => {
 })
 
 describe('sendCoins', () => {
+  const bitcoinModule = bitcoinModuleFactory(currency, 'mainnet')
+  const transactionModuleWithStubbedApiCalls = () => transactionModuleFactory("http://backendApiUrl", currency, 'mainnet')
+  const keyModule = keyModuleFactory("http://backendApiUrl", currency, 'mainnet')
+  const addressModule = addressModuleFactory("http://backendApiUrl", currency, 'mainnet')
+
   stubFeesRates(5)
   it('should exist', () => {
     const transactionModule = transactionModuleWithStubbedApiCalls()
@@ -312,13 +310,288 @@ describe('sendCoins', () => {
       .that.include(API_ERROR.INCORRECT_PASSPHRASE.errors[0])
   })
 
-  it('should send coins to testnet', async () => {
+
+  it('should sort inputs and outputs lexicographically', async () => {
+    // generates keyPairs and address
+    const userKeyPair = keyModule.generateNewKeyPair()
+    const backupKeyPair = keyModule.generateNewKeyPair()
+    const serverKeyPair = keyModule.generateNewKeyPair()
+
+    const { address } = addressModule.generateNewMultisigAddress([
+      userKeyPair.pubKey,
+      backupKeyPair.pubKey,
+      serverKeyPair.pubKey
+    ], '2/0/0')
+
+    stubUnspents({
+      change: 1.9,
+      serviceFee: {
+        amount: 0.09,
+        address: serviceAddress
+      },
+      outputs: [
+        {
+          address,
+          txHash: '11be98d68f4cc7f2a216ca72013c58935edc97954a69b8d3ea51445443b25b14',
+          n: 1,
+          path: createPath(2, 0, 0),
+          amount: new BigNumber('6.5')
+        },
+        {
+          address,
+          txHash: '10be98d68f4cc7f2a216ca72013c58935edc97954a69b8d3ea51445443b25b14',
+          n: 0,
+          path: createPath(2, 0, 0),
+          amount: new BigNumber('0.5')
+        }
+      ]
+    })
+    stubGetWallet(userKeyPair, backupKeyPair, serverKeyPair)
+    const sendTxMock = stubSendTx()
+
+    const transactionModule = transactionModuleWithStubbedApiCalls()
+
+    await transactionModule.send(
+      '1234',
+      '13',
+      [
+        {
+          address: destinationAddress,
+          amount: new BigNumber('5')
+        },
+        {
+          address: destinationAddress,
+          amount: new BigNumber('1500')
+        }
+      ],
+      userKeyPair.prvKey!,
+    )
+
+    const [, , transactionHex] = sendTxMock.mock.calls[0]
+    const tx = transactionModule.decodeTransaction(transactionHex)
+
+    expect(tx.outputs.length).to.be.eq(4)
+    expect(tx.inputs.length).to.be.eq(2)
+    expect(tx.inputs[0].txHash < tx.inputs[1].txHash).to.be.eq(true)
+    expect(tx.outputs[0].amount.isLessThan(tx.outputs[1].amount)).to.be.true
+    expect(tx.outputs[1].amount.isLessThan(tx.outputs[2].amount)).to.be.true
+  })
+})
+
+describe('sendCoins to multiple outputs', () => {
+  const bitcoinModule = bitcoinModuleFactory(currency, 'mainnet')
+  const transactionModuleWithStubbedApiCalls = () => transactionModuleFactory("http://backendApiUrl", currency, 'mainnet')
+  const keyModule = keyModuleFactory("http://backendApiUrl", currency, 'mainnet')
+  const addressModule = addressModuleFactory("http://backendApiUrl", currency, 'mainnet')
+
+  it('should exist', () => {
+    const transactionModule = transactionModuleWithStubbedApiCalls()
+    expect(transactionModule.send).to.be.a('function')
+  })
+
+  it('should send coins', async () => {
+    // generates keyPairs and address
+    const userKeyPair = keyModule.generateNewKeyPair()
+    const backupKeyPair = keyModule.generateNewKeyPair()
+    const serverKeyPair = keyModule.generateNewKeyPair()
+
+    const { address } = addressModule.generateNewMultisigAddress([
+      userKeyPair.pubKey,
+      backupKeyPair.pubKey,
+      serverKeyPair.pubKey
+    ], '2/0/0')
+
+    const inputValue = new BigNumber('7')
+    stubUnspents({
+      change: 1.9,
+      serviceFee: {
+        amount: 0.09,
+        address: serviceAddress
+      },
+      outputs: [
+        {
+          address,
+          txHash: '11be98d68f4cc7f2a216ca72013c58935edc97954a69b8d3ea51445443b25b14',
+          n: 0,
+          path: createPath(2, 0, 0),
+          amount: inputValue
+        }
+      ]
+    })
+    stubGetWallet(userKeyPair, backupKeyPair, serverKeyPair)
+    const sendTxMock = stubSendTx()
+
+    const transactionModule = transactionModuleWithStubbedApiCalls()
+
+    await transactionModule.send(
+      '1234',
+      '13',
+      [
+        {
+          address: destinationAddress,
+          amount: new BigNumber('5')
+        },
+        {
+          address: destinationAddress,
+          amount: new BigNumber('1500')
+        },
+        {
+          address,
+          amount: new BigNumber('1.99900000')
+        },
+      ],
+      userKeyPair.prvKey!,
+    )
+
+    const [, , transactionHex] = sendTxMock.mock.calls[0]
+    const tx = bitcoinModule.txFromHex(transactionHex)
+
+    expect(tx.outs.length).to.be.eq(5)
+    expect(tx.ins.length).to.be.eq(1)
+  })
+})
+
+describe('decodeTransaction', () => {
+  const transactionModuleWithStubbedApiCalls = () => transactionModuleFactory("http://backendApiUrl", currency, 'mainnet')
+  it('shoud exist', () => {
+    const transactionModule = transactionModuleWithStubbedApiCalls()
+    expect(transactionModule.decodeTransaction).to.be.a('function')
+  })
+
+  it('shoud decode transaction', () => {
+    const txHex = '0100000001145bb243544451ead3b8694a9597dc5e93583c0172ca16a2f2c74c8fd698be1102000000b40047304402205d30d1796f373290e554284fd333e3ea287709063b0461dae4577b2180787e980220121677e33785cc82b26b6a2146a34a759d15e5194dcf84c93db24e9ebcc6e374014c6952210214d16a77e4ddaa07d6dbef0ea757ea5d56f26b9bfc85534227004005c4ce102b2103e7cd55f382bcf7269dd813edd445d67de5c729b543bb20e31073ed835f661e322102c292a1d33bb482d6ab53a7328c0d0211808a785cc8769a9ac01cb3550144f37b53aeffffffff020065cd1d000000001976a914ff1cb7a5b23491534c66e7638f56d852ad47542288acf6bceb0b0000000017a91480cff499983050ec4268d749a1f898bec53e9fc28700000000'
+    const changeAmount = new BigNumber('1.99998710')
+    const sentAmount = new BigNumber('5')
+    const utxoTxHash = '11be98d68f4cc7f2a216ca72013c58935edc97954a69b8d3ea51445443b25b14'
+    const utxoTxId = 2
+
+    const transactionModule = transactionModuleWithStubbedApiCalls()
+
+    const result = transactionModule.decodeTransaction(txHex)
+
+    expect(result).to.haveOwnProperty('outputs')
+    expect(result).to.haveOwnProperty('inputs')
+    expect(result.outputs[0]).to.haveOwnProperty('amount')
+    expect(result.outputs[0]).to.haveOwnProperty('address')
+    expect(result.inputs[0]).to.haveOwnProperty('txHash')
+    expect(result.inputs[0]).to.haveOwnProperty('n')
+    expect(result.inputs).to.have.lengthOf(1)
+    expect(result.outputs).to.have.lengthOf(2)
     // @ts-ignore
-    config.networkFactory = (c: Currency) => SUPPORTED_NETWORKS[c].testnet
+    expect(result.outputs[0].amount).to.be.bignumber.eq(sentAmount)
+    expect(result.outputs[0].address).to.eq(destinationAddress)
+    // @ts-ignore
+    expect(result.outputs[1].amount).to.be.bignumber.eq(changeAmount)
+    expect(result.outputs[1].address).to.eq(changeAddress)
+    expect(result.inputs[0].txHash).to.eq(utxoTxHash)
+    expect(result.inputs[0].n).to.eq(utxoTxId)
+  })
+})
+
+describe('signTransaction', () => {
+  const transactionModuleWithStubbedApiCalls = () => transactionModuleFactory("http://backendApiUrl", currency, 'mainnet')
+  it('shoud exist', () => {
+    const transactionModule = transactionModuleWithStubbedApiCalls()
+    expect(transactionModule.signTransaction).to.be.a('function')
+  })
+
+  it('should sign transaction', () => {
+    const xprv = 'xprv9s21ZrQH143K4UVYCa2N59SDjavhZSqV2vjQYUJzV5tq4rpJNo2BjKvin1vcwFzfENabiU5eiPiXVKCsBxjNSZyQBjT36EEN4spgL1uvrTs'
+    const wrongXprv = 'xprv9s21ZrQH143K42jAsj3CsRB16Eh9MeN8SfKuiY23Aa33f2LEcVbDzBTn5QjtT83mr4wJ5LxHTMoU2DcqGVQwxrvorJJnDUL5YgQG7x2yP5c'
+    const txHex = '0100000001145bb243544451ead3b8694a9597dc5e93583c0172ca16a2f2c74c8fd698be1100000000b5004830450221009f71f64142b1381e0ccdf2b868310b1b62bb57b3de4aca0554c03c881927be0a0220236412b2c299a1fd34d1a5b1b134b5fe5f3b479bb0fb29221447adb68effb48f014c6952210317b3b652ead4367b83303c377e4b2000b707f43694a17122bd65484f9f9e76ad2102251b99fde4b9d855d6afd1782c769988f9c39fa748a90b5e8b126fb208d834302103f16c3c588e2c29d8987842823e6cf326178e60650ebc613c3fab28afc16ffc4a53aeffffffff030065cd1d000000001976a914ff1cb7a5b23491534c66e7638f56d852ad47542288ac802b530b0000000017a91480cff499983050ec4268d749a1f898bec53e9fc28740548900000000001976a914ff1cb7a5b23491534c66e7638f56d852ad47542288ac00000000'
+    const unspents: UTXO[] = [
+      {
+        txHash: '11be98d68f4cc7f2a216ca72013c58935edc97954a69b8d3ea51445443b25b14',
+        n: 0,
+        path: createPath(2, 0, 0),
+        amount: new BigNumber('7')
+      }
+    ]
+
+    const transactionModule = transactionModuleWithStubbedApiCalls()
+
+    const result = transactionModule.signTransaction(xprv, txHex, unspents)
+    expect(result.txHex).to.not.eq(txHex)
+
+    expect(() => {
+      transactionModule.signTransaction(wrongXprv, txHex, unspents)
+    }).to.throw('Key pair cannot sign for this input')
+
+    expect(() => {
+      transactionModule.signTransaction(xprv, result.txHex, unspents)
+    }).to.throw('Signature already exists')
+  })
+})
+
+describe('testnet transactions', () => {
+  const bitcoinModule = bitcoinModuleFactory(currency, 'testnet')
+  const transactionModuleWithStubbedApiCalls = () => transactionModuleFactory("http://backendApiUrl", currency, 'testnet')
+  const keyModule = keyModuleFactory("http://backendApiUrl", currency, 'testnet')
+  const addressModule = addressModuleFactory("http://backendApiUrl", currency, 'testnet')
+
+  it('should send coins to testnet and signTransaction', async () => {
     stubCreateAddress(testnetChangeAddress)
 
     // generates keyPairs and address
+    const userKeyPair = keyModule.deriveKeyPair(keyModule.generateNewKeyPair(), ROOT_DERIVATION_PATH)
+    const backupKeyPair = keyModule.deriveKeyPair(keyModule.generateNewKeyPair(), ROOT_DERIVATION_PATH)
+    const serverKeyPair = keyModule.deriveKeyPair(keyModule.generateNewKeyPair(), ROOT_DERIVATION_PATH)
 
+    const { address } = addressModule.generateNewMultisigAddress([
+      userKeyPair.pubKey,
+      backupKeyPair.pubKey,
+      serverKeyPair.pubKey
+    ], '2/1/0')
+
+    const inputValue = new BigNumber('7')
+    const unspents = [
+      {
+        address,
+        txHash: '11be98d68f4cc7f2a216ca72013c58935edc97954a69b8d3ea51445443b25b14',
+        n: 0,
+        path: createPath(2, 0, 1),
+        amount: inputValue
+      }
+    ];
+    stubUnspents({
+      change: 1.9,
+      serviceFee: {
+        amount: 0.09,
+        address: testnetServiceAddress
+      },
+      outputs: unspents
+    })
+    stubGetWallet(userKeyPair, backupKeyPair, serverKeyPair)
+    const sendTxMock = stubSendTx()
+
+    const transactionModule = transactionModuleWithStubbedApiCalls()
+
+    await transactionModule.send(
+      '1234',
+      '13',
+      [{
+        address: testnetDestinationAddress,
+        amount: new BigNumber('5')
+      }, {
+        address,
+        amount: new BigNumber('1.99990000')
+      }
+
+      ],
+      userKeyPair.prvKey!,
+    )
+
+    const [, , transactionHex] = sendTxMock.mock.calls[0]
+
+    const { txHex, txHash } = transactionModule.signTransaction(serverKeyPair.prvKey!, transactionHex, unspents);
+    expect(txHash).to.not.eq('')
+    expect(txHex).to.not.eq('')
+  })
+
+  it('should send coins', async () => {
+    stubCreateAddress(testnetChangeAddress)
+
+    // generates keyPairs and address
     const inputValue = new BigNumber('7')
     const inputValueSatoshi = 700000000
     const userKeyPair = keyModule.generateNewKeyPair()
@@ -397,76 +670,7 @@ describe('sendCoins', () => {
     expect(tx.outs.length).to.be.eq(4)
     expect(tx.ins.length).to.be.eq(1)
   })
-
-  it('should sort inputs and outputs lexicographically', async () => {
-    // generates keyPairs and address
-    const userKeyPair = keyModule.generateNewKeyPair()
-    const backupKeyPair = keyModule.generateNewKeyPair()
-    const serverKeyPair = keyModule.generateNewKeyPair()
-
-    const { address } = addressModule.generateNewMultisigAddress([
-      userKeyPair.pubKey,
-      backupKeyPair.pubKey,
-      serverKeyPair.pubKey
-    ], '2/0/0')
-
-    stubUnspents({
-      change: 1.9,
-      serviceFee: {
-        amount: 0.09,
-        address: serviceAddress
-      },
-      outputs: [
-        {
-          address,
-          txHash: '11be98d68f4cc7f2a216ca72013c58935edc97954a69b8d3ea51445443b25b14',
-          n: 1,
-          path: createPath(2, 0, 0),
-          amount: new BigNumber('6.5')
-        },
-        {
-          address,
-          txHash: '10be98d68f4cc7f2a216ca72013c58935edc97954a69b8d3ea51445443b25b14',
-          n: 0,
-          path: createPath(2, 0, 0),
-          amount: new BigNumber('0.5')
-        }
-      ]
-    })
-    stubGetWallet(userKeyPair, backupKeyPair, serverKeyPair)
-    const sendTxMock = stubSendTx()
-
-    const transactionModule = transactionModuleWithStubbedApiCalls()
-
-    await transactionModule.send(
-      '1234',
-      '13',
-      [
-        {
-          address: destinationAddress,
-          amount: new BigNumber('5')
-        },
-        {
-          address: destinationAddress,
-          amount: new BigNumber('1500')
-        }
-      ],
-      userKeyPair.prvKey!,
-    )
-
-    const [, , transactionHex] = sendTxMock.mock.calls[0]
-    const tx = transactionModule.decodeTransaction(transactionHex)
-
-    expect(tx.outputs.length).to.be.eq(4)
-    expect(tx.inputs.length).to.be.eq(2)
-    expect(tx.inputs[0].txHash < tx.inputs[1].txHash).to.be.eq(true)
-    expect(tx.outputs[0].amount.isLessThan(tx.outputs[1].amount)).to.be.true
-    expect(tx.outputs[1].amount.isLessThan(tx.outputs[2].amount)).to.be.true
-  })
-
   it('should have only three outputs when api does not return serviceFee details', async () => {
-    // @ts-ignore
-    config.networkFactory = (c: Currency) => SUPPORTED_NETWORKS[c].testnet
     stubCreateAddress(testnetChangeAddress)
 
     // generates keyPairs and address
@@ -543,207 +747,6 @@ describe('sendCoins', () => {
 
     expect(tx.outs.length).to.be.eq(3)
     expect(tx.ins.length).to.be.eq(1)
-  })
-})
-
-describe('sendCoins to multiple outputs', () => {
-  it('should exist', () => {
-    const transactionModule = transactionModuleWithStubbedApiCalls()
-    expect(transactionModule.send).to.be.a('function')
-  })
-
-  it('should send coins', async () => {
-    // generates keyPairs and address
-    const userKeyPair = keyModule.generateNewKeyPair()
-    const backupKeyPair = keyModule.generateNewKeyPair()
-    const serverKeyPair = keyModule.generateNewKeyPair()
-
-    const { address } = addressModule.generateNewMultisigAddress([
-      userKeyPair.pubKey,
-      backupKeyPair.pubKey,
-      serverKeyPair.pubKey
-    ], '2/0/0')
-
-    const inputValue = new BigNumber('7')
-    stubUnspents({
-      change: 1.9,
-      serviceFee: {
-        amount: 0.09,
-        address: serviceAddress
-      },
-      outputs: [
-        {
-          address,
-          txHash: '11be98d68f4cc7f2a216ca72013c58935edc97954a69b8d3ea51445443b25b14',
-          n: 0,
-          path: createPath(2, 0, 0),
-          amount: inputValue
-        }
-      ]
-    })
-    stubGetWallet(userKeyPair, backupKeyPair, serverKeyPair)
-    const sendTxMock = stubSendTx()
-
-    const transactionModule = transactionModuleWithStubbedApiCalls()
-
-    await transactionModule.send(
-      '1234',
-      '13',
-      [
-        {
-          address: destinationAddress,
-          amount: new BigNumber('5')
-        },
-        {
-          address: destinationAddress,
-          amount: new BigNumber('1500')
-        },
-        {
-          address,
-          amount: new BigNumber('1.99900000')
-        },
-      ],
-      userKeyPair.prvKey!,
-    )
-
-    const [, , transactionHex] = sendTxMock.mock.calls[0]
-    const tx = bitcoinModule.txFromHex(transactionHex)
-
-    expect(tx.outs.length).to.be.eq(5)
-    expect(tx.ins.length).to.be.eq(1)
-  })
-})
-
-describe('decodeTransaction', () => {
-  it('shoud exist', () => {
-    const transactionModule = transactionModuleWithStubbedApiCalls()
-    expect(transactionModule.decodeTransaction).to.be.a('function')
-  })
-
-  it('shoud decode transaction', () => {
-    const txHex = '0100000001145bb243544451ead3b8694a9597dc5e93583c0172ca16a2f2c74c8fd698be1102000000b40047304402205d30d1796f373290e554284fd333e3ea287709063b0461dae4577b2180787e980220121677e33785cc82b26b6a2146a34a759d15e5194dcf84c93db24e9ebcc6e374014c6952210214d16a77e4ddaa07d6dbef0ea757ea5d56f26b9bfc85534227004005c4ce102b2103e7cd55f382bcf7269dd813edd445d67de5c729b543bb20e31073ed835f661e322102c292a1d33bb482d6ab53a7328c0d0211808a785cc8769a9ac01cb3550144f37b53aeffffffff020065cd1d000000001976a914ff1cb7a5b23491534c66e7638f56d852ad47542288acf6bceb0b0000000017a91480cff499983050ec4268d749a1f898bec53e9fc28700000000'
-    const changeAmount = new BigNumber('1.99998710')
-    const sentAmount = new BigNumber('5')
-    const utxoTxHash = '11be98d68f4cc7f2a216ca72013c58935edc97954a69b8d3ea51445443b25b14'
-    const utxoTxId = 2
-
-    const transactionModule = transactionModuleWithStubbedApiCalls()
-
-    const result = transactionModule.decodeTransaction(txHex)
-
-    expect(result).to.haveOwnProperty('outputs')
-    expect(result).to.haveOwnProperty('inputs')
-    expect(result.outputs[0]).to.haveOwnProperty('amount')
-    expect(result.outputs[0]).to.haveOwnProperty('address')
-    expect(result.inputs[0]).to.haveOwnProperty('txHash')
-    expect(result.inputs[0]).to.haveOwnProperty('n')
-    expect(result.inputs).to.have.lengthOf(1)
-    expect(result.outputs).to.have.lengthOf(2)
-    // @ts-ignore
-    expect(result.outputs[0].amount).to.be.bignumber.eq(sentAmount)
-    expect(result.outputs[0].address).to.eq(destinationAddress)
-    // @ts-ignore
-    expect(result.outputs[1].amount).to.be.bignumber.eq(changeAmount)
-    expect(result.outputs[1].address).to.eq(changeAddress)
-    expect(result.inputs[0].txHash).to.eq(utxoTxHash)
-    expect(result.inputs[0].n).to.eq(utxoTxId)
-  })
-})
-
-describe('signTransaction', () => {
-  it('shoud exist', () => {
-    const transactionModule = transactionModuleWithStubbedApiCalls()
-    expect(transactionModule.signTransaction).to.be.a('function')
-  })
-
-  it('should sign transaction', () => {
-    const xprv = 'xprv9s21ZrQH143K4UVYCa2N59SDjavhZSqV2vjQYUJzV5tq4rpJNo2BjKvin1vcwFzfENabiU5eiPiXVKCsBxjNSZyQBjT36EEN4spgL1uvrTs'
-    const wrongXprv = 'xprv9s21ZrQH143K42jAsj3CsRB16Eh9MeN8SfKuiY23Aa33f2LEcVbDzBTn5QjtT83mr4wJ5LxHTMoU2DcqGVQwxrvorJJnDUL5YgQG7x2yP5c'
-    const txHex = '0100000001145bb243544451ead3b8694a9597dc5e93583c0172ca16a2f2c74c8fd698be1100000000b5004830450221009f71f64142b1381e0ccdf2b868310b1b62bb57b3de4aca0554c03c881927be0a0220236412b2c299a1fd34d1a5b1b134b5fe5f3b479bb0fb29221447adb68effb48f014c6952210317b3b652ead4367b83303c377e4b2000b707f43694a17122bd65484f9f9e76ad2102251b99fde4b9d855d6afd1782c769988f9c39fa748a90b5e8b126fb208d834302103f16c3c588e2c29d8987842823e6cf326178e60650ebc613c3fab28afc16ffc4a53aeffffffff030065cd1d000000001976a914ff1cb7a5b23491534c66e7638f56d852ad47542288ac802b530b0000000017a91480cff499983050ec4268d749a1f898bec53e9fc28740548900000000001976a914ff1cb7a5b23491534c66e7638f56d852ad47542288ac00000000'
-    const unspents: UTXO[] = [
-      {
-        txHash: '11be98d68f4cc7f2a216ca72013c58935edc97954a69b8d3ea51445443b25b14',
-        n: 0,
-        path: createPath(2, 0, 0),
-        amount: new BigNumber('7')
-      }
-    ]
-
-    const transactionModule = transactionModuleWithStubbedApiCalls()
-
-    const result = transactionModule.signTransaction(xprv, txHex, unspents)
-    expect(result.txHex).to.not.eq(txHex)
-
-    expect(() => {
-      transactionModule.signTransaction(wrongXprv, txHex, unspents)
-    }).to.throw('Key pair cannot sign for this input')
-
-    expect(() => {
-      transactionModule.signTransaction(xprv, result.txHex, unspents)
-    }).to.throw('Signature already exists')
-  })
-})
-
-describe('sendCoins and signTransaction', () => {
-  it('should send coins to testnet and signTransaction', async () => {
-    // @ts-ignore
-    config.networkFactory = (c: Currency) => SUPPORTED_NETWORKS[c].testnet
-    stubCreateAddress(testnetChangeAddress)
-
-    // generates keyPairs and address
-    const userKeyPair = keyModule.deriveKeyPair(keyModule.generateNewKeyPair(), ROOT_DERIVATION_PATH)
-    const backupKeyPair = keyModule.deriveKeyPair(keyModule.generateNewKeyPair(), ROOT_DERIVATION_PATH)
-    const serverKeyPair = keyModule.deriveKeyPair(keyModule.generateNewKeyPair(), ROOT_DERIVATION_PATH)
-
-    const { address } = addressModule.generateNewMultisigAddress([
-      userKeyPair.pubKey,
-      backupKeyPair.pubKey,
-      serverKeyPair.pubKey
-    ], '2/1/0')
-
-    const inputValue = new BigNumber('7')
-    const unspents = [
-      {
-        address,
-        txHash: '11be98d68f4cc7f2a216ca72013c58935edc97954a69b8d3ea51445443b25b14',
-        n: 0,
-        path: createPath(2, 0, 1),
-        amount: inputValue
-      }
-    ];
-    stubUnspents({
-      change: 1.9,
-      serviceFee: {
-        amount: 0.09,
-        address: testnetServiceAddress
-      },
-      outputs: unspents
-    })
-    stubGetWallet(userKeyPair, backupKeyPair, serverKeyPair)
-    const sendTxMock = stubSendTx()
-
-    const transactionModule = transactionModuleWithStubbedApiCalls()
-
-    await transactionModule.send(
-      '1234',
-      '13',
-      [{
-        address: testnetDestinationAddress,
-        amount: new BigNumber('5')
-      }, {
-        address,
-        amount: new BigNumber('1.99990000')
-      }
-
-      ],
-      userKeyPair.prvKey!,
-    )
-
-    const [, , transactionHex] = sendTxMock.mock.calls[0]
-
-    const { txHex, txHash } = transactionModule.signTransaction(serverKeyPair.prvKey!, transactionHex, unspents);
-    expect(txHash).to.not.eq('')
-    expect(txHex).to.not.eq('')
   })
 })
 

--- a/src/lib/tests/user.test.ts
+++ b/src/lib/tests/user.test.ts
@@ -1,11 +1,11 @@
 import { expect } from 'chai'
 
-import userFactory from '../user'
+import { userApiFactory } from '../user'
 import * as backendApiFactory from '../backend-api'
 import { hashPassword } from '../crypto';
 
 const api = backendApiFactory.create("http://backendApiUrl")
-const user = userFactory(api)
+const user = userApiFactory(api)
 
 describe('login', () => {
   it('should exist', () => {

--- a/src/lib/tests/user.test.ts
+++ b/src/lib/tests/user.test.ts
@@ -1,8 +1,16 @@
 import { expect } from 'chai'
 
-import * as user from '../user'
-import * as api from '../backend-api'
+import userFactory from '../user'
+import * as backendApiFactory from '../backend-api'
 import { hashPassword } from '../crypto';
+
+const api = backendApiFactory.create("http://backendApiUrl")
+// @ts-ignore
+backendApiFactory.create = (u) => {
+  return api
+}
+
+const user = userFactory("http://backendApiUrl")
 
 describe('login', () => {
   it('should exist', () => {

--- a/src/lib/tests/user.test.ts
+++ b/src/lib/tests/user.test.ts
@@ -5,12 +5,7 @@ import * as backendApiFactory from '../backend-api'
 import { hashPassword } from '../crypto';
 
 const api = backendApiFactory.create("http://backendApiUrl")
-// @ts-ignore
-backendApiFactory.create = (u) => {
-  return api
-}
-
-const user = userFactory("http://backendApiUrl")
+const user = userFactory(api)
 
 describe('login', () => {
   it('should exist', () => {

--- a/src/lib/tests/wallet.test.ts
+++ b/src/lib/tests/wallet.test.ts
@@ -12,7 +12,7 @@ backendApiFactory.withCurrency = (u, c) => {
   expect(c).to.eq(currency)
   return backendApi
 }
-const wallet = walletModuleFactory("http://backendApiUrl", currency)
+const wallet = walletModuleFactory("http://backendApiUrl", currency, 'mainnet')
 
 beforeEach(() => {
   use(chaiBigNumber(BigNumber))

--- a/src/lib/tests/wallet.test.ts
+++ b/src/lib/tests/wallet.test.ts
@@ -1,18 +1,18 @@
 import { expect, use } from 'chai'
 
 import { currency } from './helpers'
-import walletModuleFactory from '../wallet'
+import { walletApiFactory } from '../wallet'
 import * as backendApiFactory from '../backend-api'
 import BigNumber from 'bignumber.js'
 import chaiBigNumber from 'chai-bignumber'
 import * as pdfGen from '../keycard-pdf'
-import keyFactory from '../key'
+import { keyModuleFactory } from '../key'
 import bitcoinFactory from '../bitcoin'
 const backendApi = backendApiFactory.withCurrency("http://backendApiUrl", currency)
 
 const bitcoinOperation = bitcoinFactory(currency, 'mainnet')
-const keyModule = keyFactory(backendApi, bitcoinOperation)
-const wallet = walletModuleFactory(backendApi, keyModule)
+const keyModule = keyModuleFactory(bitcoinOperation)
+const wallet = walletApiFactory(backendApi, keyModule)
 
 beforeEach(() => {
   use(chaiBigNumber(BigNumber))

--- a/src/lib/tests/wallet.test.ts
+++ b/src/lib/tests/wallet.test.ts
@@ -6,13 +6,13 @@ import * as backendApiFactory from '../backend-api'
 import BigNumber from 'bignumber.js'
 import chaiBigNumber from 'chai-bignumber'
 import * as pdfGen from '../keycard-pdf'
-const backendApi = backendApiFactory.withCurrency(currency)
+const backendApi = backendApiFactory.withCurrency("http://backendApiUrl", currency)
 // @ts-ignore
-backendApiFactory.withCurrency = (c) => {
+backendApiFactory.withCurrency = (u, c) => {
   expect(c).to.eq(currency)
   return backendApi
 }
-const wallet = walletModuleFactory(currency)
+const wallet = walletModuleFactory("http://backendApiUrl", currency)
 
 beforeEach(() => {
   use(chaiBigNumber(BigNumber))

--- a/src/lib/tests/wallet.test.ts
+++ b/src/lib/tests/wallet.test.ts
@@ -6,13 +6,13 @@ import * as backendApiFactory from '../backend-api'
 import BigNumber from 'bignumber.js'
 import chaiBigNumber from 'chai-bignumber'
 import * as pdfGen from '../keycard-pdf'
+import keyFactory from '../key'
+import bitcoinFactory from '../bitcoin'
 const backendApi = backendApiFactory.withCurrency("http://backendApiUrl", currency)
-// @ts-ignore
-backendApiFactory.withCurrency = (u, c) => {
-  expect(c).to.eq(currency)
-  return backendApi
-}
-const wallet = walletModuleFactory("http://backendApiUrl", currency, 'mainnet')
+
+const bitcoinOperation = bitcoinFactory(currency, 'mainnet')
+const keyModule = keyFactory(backendApi, bitcoinOperation)
+const wallet = walletModuleFactory(backendApi, keyModule)
 
 beforeEach(() => {
   use(chaiBigNumber(BigNumber))

--- a/src/lib/transaction-eth.ts
+++ b/src/lib/transaction-eth.ts
@@ -5,54 +5,62 @@ import {
 } from './zlevator'
 import { Signature } from '../types/domain'
 import { hourFromNow } from './utils/helpers'
-import {
-  createETHOperationHash,
-  createTokenOperationHash,
-  createSignature
-} from './ethereum'
+import ethereumFactory from './ethereum'
 
-export const sendETH = async (
-  prvKey: string, toAddress: string, value: string, data: string, withdrawalId: string
-) => {
-  const { contractNonce, currentBlock } = await getNextNonce()
-  const expireBlock = hourFromNow(currentBlock)
-  const signature = signETHTransaction(toAddress, value, data, expireBlock, parseInt(contractNonce, 10), prvKey)
+export default (btcNetwork: string) => {
 
-  return await sendETHApi(toAddress, value, expireBlock, contractNonce, data, signature.signature, withdrawalId)
-}
+  const ethereum = ethereumFactory(btcNetwork)
 
-export const sendTokens = async (
-  prvKey: string, toAddress: string, contractAddress: string, value: string, withdrawalId: string
-) => {
-  const { contractNonce, currentBlock } = await getNextNonce()
-  const expireBlock = hourFromNow(currentBlock)
-  const signature = signTokenTransaction(toAddress, value, contractAddress, expireBlock, parseInt(contractNonce, 10), prvKey)
+  const sendETH = async (
+    prvKey: string, toAddress: string, value: string, data: string, withdrawalId: string
+  ) => {
+    const { contractNonce, currentBlock } = await getNextNonce()
+    const expireBlock = hourFromNow(currentBlock)
+    const signature = signETHTransaction(toAddress, value, data, expireBlock, parseInt(contractNonce, 10), prvKey)
 
-  return await sendTokensApi(toAddress, value, expireBlock, contractNonce, signature.signature, contractAddress, withdrawalId)
-}
-
-export const signTokenTransaction = (
-  toAddress: string, value: string, contractAddress: string, expiryDate: number,
-  contractNonce: number, ethPrvKey: string
-): Signature => {
-  const operationHash = createTokenOperationHash(toAddress, value, contractAddress, expiryDate, contractNonce)
-
-  return {
-    operationHash,
-    contractNonce,
-    signature: createSignature(operationHash, ethPrvKey)
+    return await sendETHApi(toAddress, value, expireBlock, contractNonce, data, signature.signature, withdrawalId)
   }
-}
 
-export const signETHTransaction = (
-  toAddress: string, value: string, data: string, expiryDate: number,
-  contractNonce: number, ethPrvKey: string
-): Signature => {
-  const operationHash = createETHOperationHash(toAddress, value, data, expiryDate, contractNonce)
+  const sendTokens = async (
+    prvKey: string, toAddress: string, contractAddress: string, value: string, withdrawalId: string
+  ) => {
+    const { contractNonce, currentBlock } = await getNextNonce()
+    const expireBlock = hourFromNow(currentBlock)
+    const signature = signTokenTransaction(toAddress, value, contractAddress, expireBlock, parseInt(contractNonce, 10), prvKey)
+
+    return await sendTokensApi(toAddress, value, expireBlock, contractNonce, signature.signature, contractAddress, withdrawalId)
+  }
+
+  const signTokenTransaction = (
+    toAddress: string, value: string, contractAddress: string, expiryDate: number,
+    contractNonce: number, ethPrvKey: string
+  ): Signature => {
+    const operationHash = ethereum.createTokenOperationHash(toAddress, value, contractAddress, expiryDate, contractNonce)
+
+    return {
+      operationHash,
+      contractNonce,
+      signature: ethereum.createSignature(operationHash, ethPrvKey)
+    }
+  }
+
+  const signETHTransaction = (
+    toAddress: string, value: string, data: string, expiryDate: number,
+    contractNonce: number, ethPrvKey: string
+  ): Signature => {
+    const operationHash = ethereum.createETHOperationHash(toAddress, value, data, expiryDate, contractNonce)
+
+    return {
+      operationHash,
+      contractNonce,
+      signature: ethereum.createSignature(operationHash, ethPrvKey)
+    }
+  }
 
   return {
-    operationHash,
-    contractNonce,
-    signature: createSignature(operationHash, ethPrvKey)
+    sendETH,
+    sendTokens,
+    signTokenTransaction,
+    signETHTransaction
   }
 }

--- a/src/lib/transaction.ts
+++ b/src/lib/transaction.ts
@@ -11,11 +11,11 @@ import keyFactory from './key'
 import walletApiFactory from './wallet'
 
 
-export default (currency: Currency) => {
-  const backendApi = backendApiFactory.withCurrency(currency)
+export default (backendApiUrl: string, currency: Currency) => {
+  const backendApi = backendApiFactory.withCurrency(backendApiUrl, currency)
   const bitcoin = bitcoinFactory(currency)
-  const keyApi = keyFactory(currency)
-  const walletApi = walletApiFactory(currency)
+  const keyApi = keyFactory(backendApiUrl, currency)
+  const walletApi = walletApiFactory(backendApiUrl, currency)
 
   const joinPath = (path: Path): string =>
     `${path.cosignerIndex}/${path.change}/${path.addressIndex}`

--- a/src/lib/transaction.ts
+++ b/src/lib/transaction.ts
@@ -11,11 +11,11 @@ import keyFactory from './key'
 import walletApiFactory from './wallet'
 
 
-export default (backendApiUrl: string, currency: Currency) => {
+export default (backendApiUrl: string, currency: Currency, btcNetwork: string) => {
   const backendApi = backendApiFactory.withCurrency(backendApiUrl, currency)
-  const bitcoin = bitcoinFactory(currency)
-  const keyApi = keyFactory(backendApiUrl, currency)
-  const walletApi = walletApiFactory(backendApiUrl, currency)
+  const bitcoin = bitcoinFactory(currency, btcNetwork)
+  const keyApi = keyFactory(backendApiUrl, currency, btcNetwork)
+  const walletApi = walletApiFactory(backendApiUrl, currency, btcNetwork)
 
   const joinPath = (path: Path): string =>
     `${path.cosignerIndex}/${path.change}/${path.addressIndex}`
@@ -94,7 +94,7 @@ export default (backendApiUrl: string, currency: Currency) => {
       const derivedPubKeys = pubKeys.map((key: string) => keyApi.deriveKey(key, joinPath(uns.path!)).neutered().toBase58())
       const redeemScript = bitcoin.createMultisigRedeemScript(derivedPubKeys)
       // @ts-ignore
-      bitcoin.sign(txb, idx, signingKey, new BigNumber(uns.amount),redeemScript)
+      bitcoin.sign(txb, idx, signingKey, new BigNumber(uns.amount), redeemScript)
     })
   }
 
@@ -121,7 +121,7 @@ export default (backendApiUrl: string, currency: Currency) => {
 
     unspents.forEach((uns: UTXO, idx: number) => {
       const signingKey = keyApi.deriveKey(xprv, joinPath(uns.path!)).keyPair
-      bitcoin.sign(txb,idx,signingKey,uns.amount)
+      bitcoin.sign(txb, idx, signingKey, uns.amount)
     })
 
     const builtTx = txb.build()

--- a/src/lib/transfers.ts
+++ b/src/lib/transfers.ts
@@ -1,16 +1,23 @@
-import {
-  monthlySummary as monthlySummaryBackend,
-  listTransfers as listTransfersBackend
-} from './backend-api'
+import { create } from './backend-api'
 import { ListTransfersBackendResponse, MontlySummaryBackendResponse } from '../types/response';
 
-export const monthlySummary = (token: string, month: number, year: number, fiatCurrency: number) : Promise<MontlySummaryBackendResponse> => {
-  return monthlySummaryBackend(token, month, year, fiatCurrency)
-}
+export default (backendApiUrl: string) => {
 
-export const listTransfers =  async (token: string,
-                                     walletId: string,
-                                     limit: number,
-                                     nextPageToken?: string): Promise<ListTransfersBackendResponse> => {
-  return listTransfersBackend(token,walletId,limit,nextPageToken)
+  const backend = create(backendApiUrl)
+
+  const monthlySummary = (token: string, month: number, year: number, fiatCurrency: number): Promise<MontlySummaryBackendResponse> => {
+    return backend.monthlySummary(token, month, year, fiatCurrency)
+  }
+
+  const listTransfers = async (token: string,
+    walletId: string,
+    limit: number,
+    nextPageToken?: string): Promise<ListTransfersBackendResponse> => {
+    return backend.listTransfers(token, walletId, limit, nextPageToken)
+  }
+
+  return {
+    monthlySummary,
+    listTransfers
+  }
 }

--- a/src/lib/transfers.ts
+++ b/src/lib/transfers.ts
@@ -1,15 +1,18 @@
-import { create } from './backend-api'
+import { BaseBackendApi } from './backend-api'
 import { ListTransfersBackendResponse, MontlySummaryBackendResponse } from '../types/response';
 
-export default (backendApiUrl: string) => {
+export interface TransfersApi {
+  monthlySummary(token: string, month: number, year: number, fiatCurrency: number): Promise<MontlySummaryBackendResponse>
+  listTransfers(token: string, walletId: string, limit: number, nextPageToken?: string): Promise<ListTransfersBackendResponse>
+}
 
-  const backend = create(backendApiUrl)
+export const transfersApiFactory = (backend: BaseBackendApi): TransfersApi => {
 
   const monthlySummary = (token: string, month: number, year: number, fiatCurrency: number): Promise<MontlySummaryBackendResponse> => {
     return backend.monthlySummary(token, month, year, fiatCurrency)
   }
 
-  const listTransfers = async (token: string,
+  const listTransfers = (token: string,
     walletId: string,
     limit: number,
     nextPageToken?: string): Promise<ListTransfersBackendResponse> => {

--- a/src/lib/user.ts
+++ b/src/lib/user.ts
@@ -1,38 +1,45 @@
-import {
-  confirm2fa as confirm2faBackend,
-  disable2fa as disable2faBackend,
-  info as infoBackend,
-  init2fa as init2faBackend,
-  login as loginBackend,
-  register as registerBackend,
-  setupPassword as setupPasswordBackend
-} from './backend-api'
+import { create } from './backend-api'
 import { hashPassword } from './crypto';
 
-export const login = (login: string, password: string, code?: number) => {
-  return loginBackend(login, hashPassword(password), code)
+export default (backendApiUrl: string) => {
+  const backend = create(backendApiUrl)
+
+  const login = (login: string, password: string, code?: number) => {
+    return backend.login(login, hashPassword(password), code)
+  }
+
+  const register = (login: string) => {
+    return backend.register(login)
+  }
+
+  const setupPassword = (token: string, password: string) => {
+    return backend.setupPassword(token, hashPassword(password))
+  }
+
+  const info = (token: string) => {
+    return backend.info(token)
+  }
+
+  const init2fa = (token: string, password: string) => {
+    return backend.init2fa(token, hashPassword(password))
+  }
+
+  const confirm2fa = (token: string, password: string, code: number) => {
+    return backend.confirm2fa(token, hashPassword(password), code)
+  }
+
+  const disable2fa = (token: string, password: string, code: number) => {
+    return backend.disable2fa(token, hashPassword(password), code)
+  }
+
+  return {
+    login,
+    register,
+    setupPassword,
+    info,
+    init2fa,
+    confirm2fa,
+    disable2fa
+  }
 }
 
-export const register = (login: string) => {
-  return registerBackend(login)
-}
-
-export const setupPassword = (token: string, password: string) => {
-  return setupPasswordBackend(token, hashPassword(password))
-}
-
-export const info = (token: string) => {
-  return infoBackend(token)
-}
-
-export const init2fa = (token: string, password: string) => {
-  return init2faBackend(token, hashPassword(password))
-}
-
-export const confirm2fa = (token: string, password: string, code: number) => {
-  return confirm2faBackend(token, hashPassword(password), code)
-}
-
-export const disable2fa = (token: string, password: string, code: number) => {
-  return disable2faBackend(token, hashPassword(password), code)
-}

--- a/src/lib/user.ts
+++ b/src/lib/user.ts
@@ -1,7 +1,18 @@
 import { BaseBackendApi } from './backend-api'
 import { hashPassword } from './crypto';
+import { LoginBackendResponse, RegisterBackendResponse, SetupPasswordBackendResponse, Init2faBackendResponse, Confirm2faBackendResponse, Disable2faBackendResponse, InfoBackendResponse } from 'response';
 
-export default (backend: BaseBackendApi) => {
+export interface UserApi {
+  login(login: string, password: string, code?: number): Promise<LoginBackendResponse>
+  register(login: string): Promise<RegisterBackendResponse>
+  setupPassword(token: string, password: string): Promise<SetupPasswordBackendResponse>
+  init2fa(token: string, password: string): Promise<Init2faBackendResponse>
+  confirm2fa(token: string, password: string, code: number): Promise<Confirm2faBackendResponse>
+  disable2fa(token: string, password: string, code: number): Promise<Disable2faBackendResponse>
+  info(token: string): Promise<InfoBackendResponse>
+}
+
+export const userApiFactory = (backend: BaseBackendApi): UserApi => {
 
   const login = (login: string, password: string, code?: number) => {
     return backend.login(login, hashPassword(password), code)

--- a/src/lib/user.ts
+++ b/src/lib/user.ts
@@ -1,8 +1,7 @@
-import { create } from './backend-api'
+import { BaseBackendApi } from './backend-api'
 import { hashPassword } from './crypto';
 
-export default (backendApiUrl: string) => {
-  const backend = create(backendApiUrl)
+export default (backend: BaseBackendApi) => {
 
   const login = (login: string, password: string, code?: number) => {
     return backend.login(login, hashPassword(password), code)

--- a/src/lib/wallet.ts
+++ b/src/lib/wallet.ts
@@ -5,9 +5,9 @@ import { generatePdf } from './keycard-pdf'
 import keyFactory from './key'
 import * as backendApiFactory from './backend-api'
 
-export default (currency: Currency) => {
-  const keyModule = keyFactory(currency)
-  const backendApi = backendApiFactory.withCurrency(currency)
+export default (backendApiUrl: string, currency: Currency) => {
+  const keyModule = keyFactory(backendApiUrl, currency)
+  const backendApi = backendApiFactory.withCurrency(backendApiUrl, currency)
 
   const createWallet = async (userToken: string, params: WalletParams): Promise<any> => {
     const userKeyPair = params.userPubKey ?

--- a/src/lib/wallet.ts
+++ b/src/lib/wallet.ts
@@ -1,11 +1,20 @@
 import { Recipient, WalletParams } from '../types/domain'
 import { ROOT_DERIVATION_PATH } from './constants'
-import { CreateWalletBackendParams, GetUtxosBackendParams, MaxTransferAmountParams, ReceipientsBackend } from 'response'
+import { CreateWalletBackendParams, GetUtxosBackendParams, MaxTransferAmountParams, ReceipientsBackend, MaxTransferAmountResponse, ListUnspentsBackendResponse, GetWalletBalanceBackendResponse, ListWalletsBackendResponse, GetWalletBackendResponse } from 'response'
 import { generatePdf } from './keycard-pdf'
 import { KeyModule } from './key'
 import { CurrencyBackendApi } from './backend-api';
 
-export default (backendApi: CurrencyBackendApi, keyModule: KeyModule) => {
+export interface WalletApi {
+  createWallet(userToken: string, params: WalletParams): Promise<any>
+  getWallet(userToken: string, walletId: string): Promise<GetWalletBackendResponse>
+  listWallets(userToken: string, limit: number, nextPageToken?: string): Promise<ListWalletsBackendResponse>
+  getWalletBalance(userToken: string, walletId: string): Promise<GetWalletBalanceBackendResponse>
+  listUnspents(token: string, walletId: string, feeRate: string, recipients: Recipient[]): Promise<ListUnspentsBackendResponse>
+  maxTransferAmount(token: string, walletId: string, feeRate: string, recipient: string): Promise<MaxTransferAmountResponse>
+}
+
+export const walletApiFactory = (backendApi: CurrencyBackendApi, keyModule: KeyModule): WalletApi => {
 
   const createWallet = async (userToken: string, params: WalletParams): Promise<any> => {
     const userKeyPair = params.userPubKey ?
@@ -38,15 +47,15 @@ export default (backendApi: CurrencyBackendApi, keyModule: KeyModule) => {
     return { ...response, pdf }
   }
 
-  const getWallet = (userToken: string, walletId: string) => backendApi.getWallet(userToken, walletId)
+  const getWallet = (userToken: string, walletId: string): Promise<GetWalletBackendResponse> => backendApi.getWallet(userToken, walletId)
 
-  const listWallets = (userToken: string, limit: number, nextPageToken?: string) => backendApi.listWallets(userToken, limit, nextPageToken)
+  const listWallets = (userToken: string, limit: number, nextPageToken?: string): Promise<ListWalletsBackendResponse> => backendApi.listWallets(userToken, limit, nextPageToken)
 
-  const getWalletBalance = (userToken: string, walletId: string) => backendApi.getWalletBalance(userToken, walletId)
+  const getWalletBalance = (userToken: string, walletId: string): Promise<GetWalletBalanceBackendResponse> => backendApi.getWalletBalance(userToken, walletId)
 
   const listUnspents = (
     token: string, walletId: string, feeRate: string, recipients: Recipient[]
-  ) => {
+  ): Promise<ListUnspentsBackendResponse> => {
     const params = {
       feeRate,
       recipients: recipients.map((r: Recipient) => <ReceipientsBackend>({
@@ -57,7 +66,7 @@ export default (backendApi: CurrencyBackendApi, keyModule: KeyModule) => {
     return backendApi.listUnspents(token, walletId, <GetUtxosBackendParams>params)
   }
 
-  const maxTransferAmount = (token: string, walletId: string, feeRate: string, recipient: string) => {
+  const maxTransferAmount = (token: string, walletId: string, feeRate: string, recipient: string): Promise<MaxTransferAmountResponse> => {
     const params: MaxTransferAmountParams = {
       recipient,
       feeRate

--- a/src/lib/wallet.ts
+++ b/src/lib/wallet.ts
@@ -5,8 +5,8 @@ import { generatePdf } from './keycard-pdf'
 import keyFactory from './key'
 import * as backendApiFactory from './backend-api'
 
-export default (backendApiUrl: string, currency: Currency) => {
-  const keyModule = keyFactory(backendApiUrl, currency)
+export default (backendApiUrl: string, currency: Currency, btcNetwork: string) => {
+  const keyModule = keyFactory(backendApiUrl, currency, btcNetwork)
   const backendApi = backendApiFactory.withCurrency(backendApiUrl, currency)
 
   const createWallet = async (userToken: string, params: WalletParams): Promise<any> => {

--- a/src/lib/wallet.ts
+++ b/src/lib/wallet.ts
@@ -1,13 +1,11 @@
-import { Currency, Recipient, WalletParams } from '../types/domain'
+import { Recipient, WalletParams } from '../types/domain'
 import { ROOT_DERIVATION_PATH } from './constants'
 import { CreateWalletBackendParams, GetUtxosBackendParams, MaxTransferAmountParams, ReceipientsBackend } from 'response'
 import { generatePdf } from './keycard-pdf'
-import keyFactory from './key'
-import * as backendApiFactory from './backend-api'
+import { KeyModule } from './key'
+import { CurrencyBackendApi } from './backend-api';
 
-export default (backendApiUrl: string, currency: Currency, btcNetwork: string) => {
-  const keyModule = keyFactory(backendApiUrl, currency, btcNetwork)
-  const backendApi = backendApiFactory.withCurrency(backendApiUrl, currency)
+export default (backendApi: CurrencyBackendApi, keyModule: KeyModule) => {
 
   const createWallet = async (userToken: string, params: WalletParams): Promise<any> => {
     const userKeyPair = params.userPubKey ?

--- a/src/types/response.ts
+++ b/src/types/response.ts
@@ -163,5 +163,5 @@ export interface MaxTransferAmountResponse {
 }
 
 export interface ChainInfoResponse {
-  chain: string
+  type: string
 }

--- a/src/types/response.ts
+++ b/src/types/response.ts
@@ -161,3 +161,7 @@ export interface MaxTransferAmountParams {
 export interface MaxTransferAmountResponse {
   amount: string
 }
+
+export interface ChainInfoResponse {
+  chain: string
+}


### PR DESCRIPTION
This pr consists of 3 things:
- wrap existing modules like `key`, `address`, etc with function so we can pass there some variables like e.g. backendUrl
- refactor existing code base to pass higher level objects between modules rather than bunch of primitives
- separate api and crypto related modules so users don't have to specify backendUrl if they only want to use crypto stuff